### PR TITLE
Add context menus on any control, like LibCustomMenu

### DIFF
--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -467,13 +467,26 @@ local function test()
 			if upInside and button == MOUSE_BUTTON_INDEX_RIGHT then
 				ClearCustomScrollableMenu()
 
-				AddCustomScrollableMenuEntry("Normal entry 1", function()
-					d('Custom menu Normal entry 1')
-				end)
+				local entries = {
+					{
+						name = "Test",
+						callback = function()  d("test") end,
+					}
+				}
+				AddCustomScrollableMenu(ctrl, entries, nil)
+
 
 				AddCustomScrollableMenuEntry("Normal entry 2", function()
 					d('Custom menu Normal entry 2')
 				end)
+
+				AddCustomScrollableMenuDivider()
+
+				AddCustomScrollableMenuEntry("Normal entry 1", function()
+					d('Custom menu Normal entry 1')
+				end)
+
+				SetCustomScrollableMenuOptions({sortEntries=true})
 
 				ShowCustomScrollableMenu()
 

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -473,7 +473,7 @@ local function test()
 						callback = function()  d("test") end,
 					}
 				}
-				AddCustomScrollableMenu(ctrl, entries, nil)
+				AddCustomScrollableMenu(ctrl, entries, {sortEntries=false})
 
 
 				AddCustomScrollableMenuEntry("Normal entry 2", function()

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -217,8 +217,19 @@ local function test()
 		local comboBoxMenuEntries = {
 			{
 				name            = "Normal entry 1",
-				callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
+			--	callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
+				callback        =   function(self)
 					d("Normal entry 1")
+				end,
+				contextMenuCallback =   function(self)
+					d("Normal entry 1")
+					ClearCustomScrollableMenu()
+					
+					AddCustomScrollableMenuEntry("Normal entry 1", function() d('Custom menu Normal entry 1') end)
+					
+					AddCustomScrollableMenuEntry("Normal entry 2", function() d('Custom menu Normal entry 2') end)
+					
+					ShowCustomScrollableMenu()
 				end,
 				icon			= "EsoUI/Art/TradingHouse/Tradinghouse_Weapons_Staff_Frost_Up.dds",
 				isNew			= true,
@@ -238,8 +249,17 @@ local function test()
 			},
 			{
 				name            = "Normal entry 2",
-				callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
+			--	callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
+				callback        =   function(self)
 					d("Normal entry 2")
+				end,
+				contextMenuCallback         =   function(self)
+					d("Normal entry 2")
+					ClearCustomScrollableMenu()
+					
+					AddCustomScrollableMenuEntry("Normal entry 2", function() d('Custom menu Normal entry 2') end)
+					
+					ShowCustomScrollableMenu(self)
 				end,
 				isNew			= true,
 				--entries         = submenuEntries,
@@ -438,6 +458,51 @@ local function test()
 				-- Belongs to this addon
 			end
 		end)
+
+
+		--Custom scrollable context menu
+		ZO_PlayerInventoryTabsActive:SetMouseEnabled(true)
+		ZO_PlayerInventoryTabsActive:SetHandler("OnMouseUp", function(ctrl, button, upInside)
+	d("[LSM]ZO_PlayerInventoryTabsActive - OnMouseUp")
+			if upInside and button == MOUSE_BUTTON_INDEX_RIGHT then
+				ClearCustomScrollableMenu()
+
+				AddCustomScrollableMenuEntry("Normal entry 1", function()
+					d('Custom menu Normal entry 1')
+				end)
+
+				AddCustomScrollableMenuEntry("Normal entry 2", function()
+					d('Custom menu Normal entry 2')
+				end)
+
+				ShowCustomScrollableMenu()
+
+
+				--[[
+				ClearCustomScrollableMenu()
+
+				AddCustomScrollableMenu(ZO_PlayerInventoryTabsActive, {
+					{
+						isHeader        = false,
+						name            = "Submenu Entry Test 7",
+						callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
+							d("Custom scrollable context menu entry test 1")
+						end,
+					},
+					{
+						isHeader        = false,
+						name            = "Submenu Entry Test 8",
+						callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
+							d("Custom scrollable context menu entry test 1")
+						end,
+					}
+				},
+				nil)
+				ShowCustomScrollableMenu() --ZO_PlayerInventoryTabsActive
+				]]
+			end
+		end)
+
 	end
 
 	local dropdown = lib.testDropdown
@@ -449,7 +514,6 @@ local function test()
 		testTLC:SetHidden(true)
 		testTLC:SetMouseEnabled(false)
 	end
-
 end
 lib.Test = test
 --	/script LibScrollableMenu.Test()

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -489,32 +489,35 @@ local function test()
 				SetCustomScrollableMenuOptions({sortEntries=true})
 
 				ShowCustomScrollableMenu()
-
-
-				--[[
-				ClearCustomScrollableMenu()
-
-				AddCustomScrollableMenu(ZO_PlayerInventoryTabsActive, {
-					{
-						isHeader        = false,
-						name            = "Submenu Entry Test 7",
-						callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
-							d("Custom scrollable context menu entry test 1")
-						end,
-					},
-					{
-						isHeader        = false,
-						name            = "Submenu Entry Test 8",
-						callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
-							d("Custom scrollable context menu entry test 1")
-						end,
-					}
-				},
-				nil)
-				ShowCustomScrollableMenu() --ZO_PlayerInventoryTabsActive
-				]]
 			end
 		end)
+
+		ZO_PlayerInventoryMenuBarButton1:SetHandler("OnMouseUp", function(ctrl, button, upInside)
+	d("[LSM]ZO_PlayerInventoryMenuBarButton1 - OnMouseUp")
+			if upInside and button == MOUSE_BUTTON_INDEX_RIGHT then
+				ClearCustomScrollableMenu()
+
+				local entries = {
+					{
+						name = "Test 2",
+						callback = function()  d("test") end,
+					}
+				}
+				AddCustomScrollableMenu(ctrl, entries, nil)
+
+
+				AddCustomScrollableMenuEntry("Normal entry 2 - 2", function()
+					d('Custom menu Normal entry 2')
+				end)
+
+				AddCustomScrollableMenuEntry("Normal entry 1 - 2", function()
+					d('Custom menu Normal entry 1')
+				end)
+
+				ShowCustomScrollableMenu(nil, nil, nil, nil, nil, {sortEntries=true})
+			end
+		end)
+
 
 	end
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1172,7 +1172,7 @@ function ScrollableDropdownHelper:GetOptions()
 end
 
 function ScrollableDropdownHelper:UpdateOptions(options)
-	d( sfor('optionsChanged %s', tostring(self.optionsChanged)))
+	--d(sfor('[LSM]UpdateOptionsoptionsChanged %s', tostring(self.optionsChanged)))
 
 	if not self.optionsChanged then return end
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -243,6 +243,10 @@ local function recursiveOverEntries(entry, callback)
 	
 	local result = callback(entry)
 	local submenu = entry.entries or {}
+
+	local submenuType = type(submenu)
+	assert(submenuType == 'table', sfor('[LibScrollableMenu:recursiveOverEntries] table expected, got %q = %s', "submenu", tos(submenuType)))
+
 	if #submenu > 0 then
 		for k, subEntry in pairs(submenu) do
 			local subEntryResult = recursiveOverEntries(subEntry, callback)
@@ -341,7 +345,7 @@ local function mapEntries(entryTable, mapTable, blank)
     end
 	
 	local entryTableType, mapTableType = type(entryTable), type(mapTable)
-	assert(entryTableType == 'table' and mapTableType == 'table' , sfor('[LibScrollableMenu:MapEntries] tables expected got entryTable = %s, mapTable = %s', tos(entryTableType), tos(mapTableType)))
+	assert(entryTableType == 'table' and mapTableType == 'table' , sfor('[LibScrollableMenu:MapEntries] tables expected, got %q = %s, %q = %s', "entryTable", tos(entryTableType), "mapTable", tos(mapTableType)))
 	
 	-- Splitting these up so the above is not done each iteration
 	doMapEntries(entryTable, mapTable)
@@ -1750,7 +1754,7 @@ function SetCustomScrollableMenuOptions(options, scrollHelper)
 	scrollHelper = scrollHelper or getScrollHelperObjectFromControl(customScrollableMenuComboBox)
 
 	options = options or scrollHelper.options
-	assert(optionsTableType == 'table' , sfor('[LibScrollableMenu:SetCustomScrollableMenuOptions] table expected got options = %s', tos(optionsTableType)))
+	assert(optionsTableType == 'table' , sfor('[LibScrollableMenu:SetCustomScrollableMenuOptions] table expected, got %q = %s', "options", tos(optionsTableType)))
 	scrollHelper.optionsChanged = options ~= scrollHelper.options
 	scrollHelper:UpdateOptions(options)
 end
@@ -1760,7 +1764,7 @@ setCustomScrollableMenuOptions = SetCustomScrollableMenuOptions
 --You can add more entries later via AddCustomScrollableMenuEntry function too
 function AddCustomScrollableMenu(parent, entries, options)
 	local entryTableType = type(entries)
-	assert(entryTableType == 'table' , sfor('[LibScrollableMenu:AddCustomScrollableMenu] table expected got entries = %s', tos(entryTableType)))
+	assert(entryTableType == 'table' , sfor('[LibScrollableMenu:AddCustomScrollableMenu] table expected, got %q = %s', "entries", tos(entryTableType)))
 
 	-- the menu is only being added to the first parent
 	--parent should be changed every time it's shown. so it can be the correct control even if from another addon

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1604,18 +1604,22 @@ local function onGlobalMouseDown()
 --d("[LSM]OnGlobalMouseUp-refCount: " ..tos(refCount))
     if refCount ~= nil then
         local moc = moc()
-		local parent = customScrollableMenuComboBox:GetParent()
+		local owningWindowIsNotZO_Menus = moc:GetOwningWindow() ~= ZO_Menus
+		local owner = moc.m_owner
+		local isOwnerNil = owner == nil
+		local container = getContainerFromControl(moc)
 
         --Or the owning window ZO_Menus (the onwer of our DUMMY ZO_ComboBox for the custom scrollable context menu)
 		--or is the m_owner variable provided (tells us we got a ScrollHelper entry here -> main menu or submenu)
-		if moc:GetOwningWindow() ~= ZO_Menus or moc.m_owner == nil then
-            refCount = refCount - 1
-            mouseDownRefCounts[customScrollableMenuComboBox] = refCount
-            if refCount <= 0 then
+		if owningWindowIsNotZO_Menus or isOwnerNil or container ~= customScrollableMenuComboBox then
+			if owningWindowIsNotZO_Menus and not isOwnerNil and owner.m_submenu ~= nil then return end
+			refCount = refCount - 1
+			mouseDownRefCounts[customScrollableMenuComboBox] = refCount
+			if refCount <= 0 then
 				clearCustomScrollableMenu = clearCustomScrollableMenu or ClearCustomScrollableMenu
-                clearCustomScrollableMenu()
-            end
-        end
+				clearCustomScrollableMenu()
+			end
+		end
     end
 end
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1677,7 +1677,9 @@ function AddCustomScrollableMenuEntry(text, callback, entryType, entries, isNew)
 	if not allowedEntryTypesForContextMenu[entryType] then
 		entryType = lib.LSM_ENTRY_TYPE_NORMAL
 	end
-	assert(((entryType ~= lib.LSM_ENTRY_TYPE_HEADER and entryType ~= lib.LSM_ENTRY_TYPE_DIVIDER) and type(callback) ~= "function"), sfor('[LibScrollableMenu:AddCustomScrollableMenuEntry] Callback function expected, got %q = %s', "callback", tos(callback)))
+	if entryType ~= lib.LSM_ENTRY_TYPE_HEADER and entryType ~= lib.LSM_ENTRY_TYPE_DIVIDER and entries == nil then
+		assert(type(callback) == "function", sfor('[LibScrollableMenu:AddCustomScrollableMenuEntry] Callback function expected, got %q = %s', "callback", tos(callback)))
+	end
 
 	-->Todo: if entryType is not in lib.allowedContextMenuEntryTypes then change to lib.LSM_ENTRY_TYPE_NORMAL
 	--Or is it a header line?

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1617,12 +1617,17 @@ local function onGlobalMouseDown()
 		local owner = moc.m_owner
 		local isOwnerNil = owner == nil
 		local container = getContainerFromControl(moc)
+		local parent = moc:GetParent()
+		local isScrollbar = moc.scrollbar ~= nil or (parent ~= nil and parent.scrollbar ~= nil)
 
+--d("[onGlobalMouseDown]owningWindowIsNotZO_Menus: " ..tos(owningWindowIsNotZO_Menus) .. ", isOwnerNil: " ..tos(isOwnerNil) .. ", container: " .. tos(container ~= nil and container:GetName()) .. ", contextMenuCtrl: " ..tos(customScrollableMenuComboBox:GetName()))
+		--Scrollbar and the onwing window is ZO_Menus?
+		if isScrollbar and not owningWindowIsNotZO_Menus then
+			return
+		end
         --Or the owning window ZO_Menus (the onwer of our DUMMY ZO_ComboBox for the custom scrollable context menu)
 		--or is the m_owner variable provided (tells us we got a ScrollHelper entry here -> main menu or submenu)
---d("[onGlobalMouseDown]owningWindowIsNotZO_Menus: " ..tos(owningWindowIsNotZO_Menus) .. ", isOwnerNil: " ..tos(isOwnerNil) .. ", container: " .. tos(container ~= nil and container:GetName()) .. ", contextMenuCtrl: " ..tos(customScrollableMenuComboBox:GetName()))
-
-		if owningWindowIsNotZO_Menus or isOwnerNil or (container ~= nil and container ~= customScrollableMenuComboBox) then
+		if (owningWindowIsNotZO_Menus or isOwnerNil or (container ~= nil and container ~= customScrollableMenuComboBox)) then
 --d(">is no main menu entry, maybe a Submenu entry?")
 			if not owningWindowIsNotZO_Menus and not isOwnerNil and owner.m_submenu ~= nil then
 --d(">>isSubmenu entry")

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1677,7 +1677,7 @@ function AddCustomScrollableMenuEntry(text, callback, entryType, entries, isNew)
 	if not allowedEntryTypesForContextMenu[entryType] then
 		entryType = lib.LSM_ENTRY_TYPE_NORMAL
 	end
-	assert(((entryType ~= lib.LSM_ENTRY_TYPE_HEADER and entryType ~= lib.LSM_ENTRY_TYPE_DIVIDER) and type(callback) == "function"), sfor('[LibScrollableMenu:AddCustomScrollableMenuEntry] Callback function expected, got %q = %s', "callback", tos(callback)))
+	assert(((entryType ~= lib.LSM_ENTRY_TYPE_HEADER and entryType ~= lib.LSM_ENTRY_TYPE_DIVIDER) and type(callback) ~= "function"), sfor('[LibScrollableMenu:AddCustomScrollableMenuEntry] Callback function expected, got %q = %s', "callback", tos(callback)))
 
 	-->Todo: if entryType is not in lib.allowedContextMenuEntryTypes then change to lib.LSM_ENTRY_TYPE_NORMAL
 	--Or is it a header line?

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1632,9 +1632,17 @@ d("[LSM]InitCustomScrollableMenu-parent: " ..tos(parent:GetName()))
 
 	lib.customContextMenu = customScrollableMenuComboBox
 
-	local scrollHelper = addCustomScrollableComboBoxDropdownMenu(parent, customScrollableMenuComboBox, options or defaultContextMenuOptions)
+	--Always set default context menu values for this menu scrollHelper
+	local scrollHelper = addCustomScrollableComboBoxDropdownMenu(parent, customScrollableMenuComboBox, defaultContextMenuOptions)
 	customScrollableMenuComboBox.scrollHelper = scrollHelper
+
+	--Clear internal tables and variables
 	scrollHelper:InitContextMenuValues()
+
+	--If custom options were provided: Mix them in to defaults
+	if options ~= nil then
+		scrollHelper:UpdateOptions(options)
+	end
 
 	return scrollHelper
 end
@@ -1652,8 +1660,9 @@ function AddCustomScrollableMenuEntry(text, callback, entryType, isNew, entries)
 		isCheckbox		= entryType == ENTRY_TYPE_CHECKBOX,
 		isNew        	= getValueOrCallback(isNew, options) or false,
 		name            = getValueOrCallback(text, options),
+		callback        = callback,							--ZO_ComboBox:SelectItem will call the item.callback(self, item.name, item), where item = { isHeader = ... }
+		--Submenu?
 		entries			= entries, --For submenus
-		callback        = callback,
 	})
 end
 addCustomScrollableMenuEntry = AddCustomScrollableMenuEntry

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -858,18 +858,20 @@ function ScrollableDropdownHelper:AddMenuItems()
 		item.m_owner = self
 
 		local isHeader = getValueOrCallback(item.isHeader, item)
+		local isDivider = (item.label ~= nil and getValueOrCallback(item.label, item) == libDivider) or getValueOrCallback(item.name, item) == libDivider
 		local isCheckbox = getValueOrCallback(item.isCheckbox, item)
 		--local isCheckboxChecked = GetValueOrCallback(item.checked, item)
 		--local icon = GetValueOrCallback(item.icon, item)
 
 		local hasSubmenu = item.entries ~= nil
 
-		local entryType = (item.name == libDivider and DIVIDER_ENTRY_ID) or (isCheckbox and CHECKBOX_ENTRY_ID) or (isHeader and HEADER_ENTRY_ID) or
+		local entryType = (isDivider and DIVIDER_ENTRY_ID) or (isCheckbox and CHECKBOX_ENTRY_ID) or (isHeader and HEADER_ENTRY_ID) or
 				(hasSubmenu and SUBMENU_ENTRY_ID) or (isLast and LAST_ENTRY_ID) or ENTRY_ID
 		if hasSubmenu then
 			item.hasSubmenu = true
 			item.isNew = areAnyEntriesNew(item)
 		end
+		item.isDivider = isDivider
 
 		--Save divider and header entries' indices for later usage at the height calulation
 		if rowIndex[entryType] ~= nil then
@@ -956,17 +958,17 @@ end
 function ScrollableDropdownHelper:GetMaxWidth(item, maxWidth, dividers, headers)
 	local fontObject = _G[item.m_owner.m_font]
 	
-	if item.name == libDivider then
+	local labelStr = getValueOrCallback(item.name, item)
+	if item.label ~= nil then
+		labelStr = getValueOrCallback(item.label, item)
+	end
+
+	if item.isDivider or labelStr == libDivider then
 		dividers = dividers + 1
 	elseif item.isHeader then
 		headers = headers + 1
 	end
-	
-	local labelStr = item.name
-	if item.label ~= nil then
-		labelStr = getValueOrCallback(item.label, item)
-	end
-	
+
 	local submenuEntryPadding = item.hasSubmenu and SCROLLABLE_ENTRY_TEMPLATE_HEIGHT or 0
 	local iconPadding = (item.icon ~= nil or item.isNew == true) and ICON_PADDING or 0 -- NO_ICON_PADDING
 	local width = GetStringWidthScaled(fontObject, labelStr, 1, SPACE_INTERFACE) + iconPadding + submenuEntryPadding
@@ -1700,7 +1702,7 @@ function AddCustomScrollableMenuEntry(text, callback, entryType, entries, isNew)
 	--Or a clickable checkbox line?
 	local isCheckbox = entryType == lib.LSM_ENTRY_TYPE_CHECKBOX
 	--or just a ---------- divider line?
-	local isDivider = text == libDivider or entryType == lib.LSM_ENTRY_TYPE_DIVIDER
+	local isDivider = entryType == lib.LSM_ENTRY_TYPE_DIVIDER or text == libDivider
 	if isDivider == true then entryType = lib.LSM_ENTRY_TYPE_DIVIDER end
 
 	--Add the line of the context menu to the internal tables. Will be read as the ZO_ComboBox's dropdown opens and calls

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1704,6 +1704,11 @@ function AddCustomScrollableMenuEntry(text, callback, entryType, entries, isNew)
 end
 addCustomScrollableMenuEntry = AddCustomScrollableMenuEntry
 
+--Adds an entry having a submenu (or maybe nested submenues) in the entries table
+function AddCustomScrollableSubMenuEntry(text, entries)
+	addCustomScrollableMenuEntry(text, nil, lib.LSM_ENTRY_TYPE_NORMAL, entries, nil)
+end
+
 --Adds a divider line to the context menu entries
 function AddCustomScrollableMenuDivider()
 	addCustomScrollableMenuEntry(libDivider, nil, lib.LSM_ENTRY_TYPE_DIVIDER, nil, nil)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -244,10 +244,10 @@ local function recursiveOverEntries(entry, callback)
 	local result = callback(entry)
 	local submenu = entry.entries or {}
 
-	local submenuType = type(submenu)
-	assert(submenuType == 'table', sfor('[LibScrollableMenu:recursiveOverEntries] table expected, got %q = %s', "submenu", tos(submenuType)))
+	--local submenuType = type(submenu)
+	--assert(submenuType == 'table', sfor('[LibScrollableMenu:recursiveOverEntries] table expected, got %q = %s', "submenu", tos(submenuType)))
 
-	if #submenu > 0 then
+	if  type(submenu) == "table" and #submenu > 0 then
 		for k, subEntry in pairs(submenu) do
 			local subEntryResult = recursiveOverEntries(subEntry, callback)
 			if subEntryResult then

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 1.6
-## AddOnVersion: 0106
+## Version: 1.7
+## AddOnVersion: 0107
 ## IsLibrary: true
 ## Author: tomstock, Baertram, IsJustaGhost (, Kyoma)
 ## APIVersion: 101040 101041
@@ -16,4 +16,4 @@ LibScrollableMenu.xml
 
 ## Uncomment this to test the combobox with different menu entryTypes and submenus
 ## Use slash command /lsmtest to show the test UI
-## LSM_test.lua
+LSM_test.lua

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -47,6 +47,7 @@
 			</OnInitialized>
 			
 			<OnMouseUp>
+			--	LibScrollableMenu_OnSelected(self, self == WINDOW_MANAGER:GetMouseOverControl())
 				LibScrollableMenu_OnSelected(self, button, upInside)
 			</OnMouseUp>
 			
@@ -133,6 +134,11 @@
 					<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" />
 				</Control>
 			</Controls>
+		</Control>
+
+		<Control name="LibScrollableMenu_CustomContextMenu_ComboBox" inherits="ZO_ComboBox" mouseEnabled="false" clampedToScreen="true" hidden="true" virtual="true">
+			<Dimensions x="135"  y="31"/>
+			<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" />
 		</Control>
 	</Controls>
 </GuiXml>


### PR DESCRIPTION
Syntax:

--Adds a new entry to the context menu entries with the shown text, which calls the callback function once clicked.
--If entries is provided the entry will be a submenu having those entries. The callback can only be used if entries are passed in
--but normally it should be nil in that case
function AddCustomScrollableMenuEntry(text, callback, entryType, entries, isNew)

--Adds an entry having a submenu (or maybe nested submenues) in the entries table
function AddCustomScrollableSubMenuEntry(text, entries)

--Adds a divider line to the context menu entries
function AddCustomScrollableMenuDivider()

--Pass in a table with predefined context menu entries and let them all be added in order of the table's number key
function AddCustomScrollableMenuEntries(contextMenuEntries)

--Set the options (visible rows max, etc.) for the scrollable context menu
function SetCustomScrollableMenuOptions(options, scrollHelper)

--Add a new scrollable context menu with the defined entries table.
--You can add more entries later via AddCustomScrollableMenuEntry function too
function AddCustomScrollableMenu(parent, entries, options)

--Show the custom scrollable context menu now
function ShowCustomScrollableMenu(controlToAnchorTo, point, relativePoint, offsetX, offsetY, options)

--Hide the custom scrollable context menu and clear internal variables, mouse clicks etc.
function ClearCustomScrollableMenu()