### PR TITLE
Version 2 3 2

### DIFF
--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -560,6 +560,7 @@ d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollab
 				callback 		= function(comboBox, itemName, item, selectionChanged, oldItem)
 					d("I clicked a button with the name: " .. tostring(itemName))
 				end,
+				doNotFilter		= true,
 			},
 			{
 				entryType		= LSM_ENTRY_TYPE_RADIOBUTTON,
@@ -571,6 +572,7 @@ d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollab
 					d("I clicked Radiobutton group 1-1 with the name: " .. tostring(itemName))
 				end,
 				buttonGroup = 1,
+				doNotFilter		= true,
 			},
 			{
 				entryType		= LSM_ENTRY_TYPE_RADIOBUTTON,

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -825,7 +825,7 @@ do
 			control:SetHidden(true)
 
 			local hidden = not refreshResults[controlId]
-			-- There are no other header controls showing, so hide the togle button
+			-- There are no other header controls showing, so hide the toggle button, and it's extension
 			if not collapsed and (controlId == TOGGLE_BUTTON or controlId == TOGGLE_BUTTON_CLICK_EXTENSION) and g_currentBottomLeftHeader == DEFAULT_CONTROLID then
 				hidden = true
 			end
@@ -2388,6 +2388,14 @@ local lastEntryVisible  = true	--Was the last entry processed visible at the res
 local filterString				--the search string
 local filterFunc				--the filter function to use. Default is "defaultFilterFunc". Custom filterFunc can be added via options.customFilterFunc
 
+--options.customFilterFunc needs the same signature/parameters like this function
+--return value needs to be a boolean: true = found/false = not found
+-->Attention: prefix "/" in the filterString still jumps this function for submenus as non-matching will be always found that way!
+local function defaultFilterFunc(p_item, p_filterString)
+	local name = p_item.label or p_item.name
+	return zo_strlower(name):find(p_filterString) ~= nil
+end
+
 --Check if entry should be added to the search/filter of the string search of the collapsible header
 -->Returning true: item must be considered for the search / false: item should be skipped
 local function passItemToSearch(item)
@@ -2399,14 +2407,6 @@ local function passItemToSearch(item)
 		return not filterNamesExempts[name]
 	end
 	return false
-end
-
---options.customFilterFunc needs the same signature/parameters like this function
---return value needs to be a boolean: true = found/false = not found
--->Attention: prefix "/" in the filterString still jumps this function for submenus as non-matching will be always found that way!
-local function defaultFilterFunc(p_item, p_filterString)
-	local name = p_item.label or p_item.name
-	return zo_strlower(name):find(p_filterString) ~= nil
 end
 
 --Search the item's label or name now, if the entryType of the item should be processed by text search, and if the entry

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -946,15 +946,17 @@ end
 -- Local functions
 --------------------------------------------------------------------
 
+local throttledCallDelaySuffixCounter = 0
 local function throttledCall(callback, delay, throttledCallNameSuffix)
 	delay = delay or throttledCallDelay
-	throttledCallNameSuffix = throttledCallNameSuffix or ""
-	dLog(LSM_LOGTYPE_VERBOSE, "REGISTERING throttledCall - callback: %s, delay: %s", tos(callback), tos(delay))
+	throttledCallDelaySuffixCounter = throttledCallDelaySuffixCounter + 1
+	throttledCallNameSuffix = throttledCallNameSuffix or tos(throttledCallDelaySuffixCounter)
 	local throttledCallDelayTotalName = throttledCallDelayName .. throttledCallNameSuffix
+	dLog(LSM_LOGTYPE_VERBOSE, "REGISTERING throttledCall - callback: %s, delay: %s, name: %s", tos(callback), tos(delay), tos(throttledCallDelayTotalName))
 	EM:UnregisterForUpdate(throttledCallDelayTotalName)
 	EM:RegisterForUpdate(throttledCallDelayTotalName, delay, function()
 		EM:UnregisterForUpdate(throttledCallDelayTotalName)
-		dLog(LSM_LOGTYPE_VERBOSE, "DELAYED throttledCall -> CALLING callback now: %s", tos(callback))
+		dLog(LSM_LOGTYPE_VERBOSE, "DELAYED throttledCall -> CALLING callback now: %s, name: %s", tos(callback), tos(throttledCallDelayTotalName))
 		callback()
 	end)
 end

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -9,7 +9,7 @@ lib.name = "LibScrollableMenu"
 local MAJOR = lib.name
 
 lib.author = "IsJustaGhost, Baertram, tomstock, Kyoma"
-lib.version = "2.31"
+lib.version = "2.32"
 
 if not lib then return end
 
@@ -280,7 +280,7 @@ local possibleEntryDataWithFunction = {
 ------------------------------------------------------------------------------------------------------------------------
 --Default options/settings and values
 
---ZO_ComboBox default settings: Will be copied over as default attributes to comboBoxClass and inherited scrollable
+--ZO_ComboBox default settings: Will be copied over as default attributes to comboBoxClass and inherited to the scrollable
 --dropdown helper classes
 local comboBoxDefaults = {
 	--From ZO_ComboBox
@@ -417,6 +417,7 @@ lib.LSMOptionsToZO_ComboBoxOptionsCallbacks = LSMOptionsToZO_ComboBoxOptionsCall
 
 -- Pass-through variables:
 --If submenuClass_exposedVariables[key] == true: if submenu[key] is nil, returns submenu.m_comboBox[key]
+--> where key = e.g. "m_font"
 local submenuClass_exposedVariables = {
 	-- ZO_ComboBox
 	["m_font"] = true, --
@@ -470,13 +471,13 @@ local submenuClass_exposedFunctions = {
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Search filter
-
+--No entry found in main menu
 local noEntriesResults = {
 	enabled = false,
 	name = GetString(SI_SORT_FILTER_LIST_NO_RESULTS),
 	m_disabledColor = DEFAULT_TEXT_DISABLED_COLOR,
 }
-
+--No entry found in sub menu
 local noEntriesSubmenu = {
 	name = GetString(SI_QUICKSLOTS_EMPTY),
 	enabled = false,
@@ -494,11 +495,11 @@ local filteredEntryTypes = {
 	[LSM_ENTRY_TYPE_RADIOBUTTON] = true,
 	--[LSM_ENTRY_TYPE_DIVIDER] = false,
 }
---Table defines if some names of the entries count as "to search" or not.
---true: Item's name does not need to be searched / false: search the item's name
+--Table defines if some names of the entries count as "search them or skip them".
+--true: Item's name does not need to be searched -> skip them / false: search the item's name as usual
 local filterNamesExempts = {
 	--Direct check via "name" string
-	[''] = true,
+	[""] = true,
 	[noEntriesSubmenu.name] = true, -- "Empty"
 	--Check via type(name)
 	--['nil'] = true,
@@ -1260,6 +1261,8 @@ local function verifyLabelString(data)
 end
 
 -- Recursively loop over drdopdown entries, and submenu dropdown entries of that parent dropdown, and check if e.g. isNew needs to be updated
+-- Used for the search of the collapsible header too
+-- Param updateSubmenuValues boolean controls if the submenu's values like additionalData subtable should be updated too (via function preUpdateSubItems)
 local function recursiveOverEntries(entry, callback, updateSubmenuValues)
 	callback = callback or defaultRecursiveCallback
 	
@@ -1268,7 +1271,7 @@ local function recursiveOverEntries(entry, callback, updateSubmenuValues)
 
 	--local submenuType = type(submenu)
 	--assert(submenuType == 'table', sfor('['..MAJOR..':recursiveOverEntries] table expected, got %q = %s', "submenu", tos(submenuType)))
-	if  type(submenu) == "table" and #submenu > 0 then
+	if type(submenu) == "table" and #submenu > 0 then
 		for _, subEntry in pairs(submenu) do
 			local subEntryResult = recursiveOverEntries(subEntry, callback, updateSubmenuValues)
 			if subEntryResult then
@@ -1583,7 +1586,7 @@ lib.getComboBoxsSortedItems = getComboBoxsSortedItems
 --Functions to run per item's entryType, after the item has been setup (e.g. to add missing mandatory data or change visuals)
 local postItemSetupFunctions = {
 	[LSM_ENTRY_TYPE_SUBMENU] = function(comboBox, itemEntry)
-		itemEntry.isNew = recursiveOverEntries(itemEntry, preUpdateSubItems)
+		itemEntry.isNew = recursiveOverEntries(itemEntry, preUpdateSubItems, nil)
 	end,
 	[LSM_ENTRY_TYPE_HEADER] = function(comboBox, itemEntry)
 		itemEntry.font = itemEntry.font or comboBox.m_headerFont
@@ -2016,16 +2019,16 @@ Function to show and hide a custom tooltip control. Pass that in to the data tab
 Your function needs to create and show/hide that control, and populate the text etc to the control too!
 Parameters:
 -control The control the tooltip blongs to
--inside boolean to show if your mouse is inside the control. Will be false if tooltip should hide
+-doShow boolean to show if your mouse is inside the control and should show the tooltip. Must be false if tooltip should hide
 -data The table with the current data of the rowControl
 	-> To distinguish if the tooltip should be hidden or shown:	If 1st param data is missing the tooltip will be hidden! If data is provided the tooltip wil be shown
 -rowControl The userdata of the control the tooltip should show about
 -point, offsetX, offsetY, relativePoint: Suggested anchoring points
 
 Example - Show an item tooltip of an inventory item
-data.customTooltip = function(control, inside, data, relativeTo, point, offsetX, offsetY, relativePoint)
+data.customTooltip = function(control, doShow, data, relativeTo, point, offsetX, offsetY, relativePoint)
 	ClearTooltip(ItemTooltip)
-	if inside and data then
+	if doShow and data then
 		InitializeTooltip(ItemTooltip, relativeTo, point, offsetX, offsetY, relativePoint)
 		ItemTooltip:SetBagItem(data.bagId, data.slotIndex)
 		ItemTooltipTopLevel:BringWindowToTop()
@@ -2033,7 +2036,7 @@ data.customTooltip = function(control, inside, data, relativeTo, point, offsetX,
 end
 
 Another example using a custom control of your addon to show the tooltip:
-customTooltipFunc = function(control, inside, data, rowControl, point, offsetX, offsetY, relativePoint)
+customTooltipFunc = function(control, doShow, data, rowControl, point, offsetX, offsetY, relativePoint)
 	if not inside or data == nil then
 		myAddon.myTooltipControl:SetHidden(true)
 	else
@@ -2373,15 +2376,17 @@ local lastEntryVisible  = true	--Was the last entry processed visible at the res
 local filterString				--the search string
 local filterFunc				--the filter function to use. Default is "defaultFilterFunc". Custom filterFunc can be added via options.customFilterFunc
 
---Check if name of entry counts as "to search", or not
--->Returning true: item's name does not need to be searched / false: search the item's name
-local function filterNameExempt(item)
-	if filterString ~= '' then
+--Check if entry should be added to the search/filter of the string search of the collapsible header
+-->Returning true: item must be considered for the search / false: item should be skipped
+local function passItemToSearch(item)
+	--Check if name of entry counts as "to search", or not
+	if filterString ~= "" then
 		local name = item.label or item.name
-		return name == nil or filterNamesExempts[name] --or filterNamesExempts[type(name)] --> Shows nil too
-	else
-		return true
+		--Name is missing: Do not filter
+		if name == nil then return false end
+		return not filterNamesExempts[name]
 	end
+	return false
 end
 
 --options.customFilterFunc needs the same signature/parameters like this function
@@ -2392,11 +2397,18 @@ local function defaultFilterFunc(p_item, p_filterString)
 	return zo_strlower(name):find(p_filterString) ~= nil
 end
 
---Search the item's label or name now, if the entryType of the item should be processed by text search
+--Search the item's label or name now, if the entryType of the item should be processed by text search, and if the entry
+--was not marked as "not to search" (always show in search results) in it's data
 local function filterResults(item)
 	local entryType = item.entryType
 	if not entryType or filteredEntryTypes[entryType] then
-		if not filterNameExempt(item) then
+		--Should the item be skipped at the search filters?
+		local doNotFilter = getValueOrCallback(item.doNotFilter, item) or false
+		if doNotFilter == true then
+			return true -- always included
+		end
+		--Check for other prerequisites
+		if passItemToSearch(item) == true then
 			--Not excluded, do the string comparison now
 			return filterFunc(item, filterString)
 		end
@@ -2412,7 +2424,7 @@ local function itemPassesFilter(item, doFilter)
 	if verifyLabelString(item) then
 		if doFilter then
 			--Recursively check menu entries (submenu and nested submenu entries) for the matching search string
-			return recursiveOverEntries(item, filterResults)
+			return recursiveOverEntries(item, filterResults, nil)
 		else
 			return true
 		end
@@ -5421,11 +5433,10 @@ LibScrollableMenu = lib
 
 --[[
 -------------------
-WORKING ON - Current version: 2.31
+WORKING ON - Current version: 2.32
 -------------------
-	1. Bug: Clicking a checkbox/button in a context menu's submenu closes the context menu
-	TESTED: BUG
-
+	1. Feature: Add attribute ".doNotFilter boolean" to all entryTypes. If true then do not hide those controls if a search/filter is used
+	   -> e.g. used for a button "Apply changes" at a submenu to apply checkboxes checked/unchecked state now even if search filter was hiding non-matching checkboxes
 
 
 -------------------
@@ -5433,32 +5444,10 @@ TODO - To check (future versions)
 -------------------
 
 	1. Make Options update same style like updateDataValues does for entries
-	2. Accept a custom filter function
-	3. Attention: zo_comboBox_base_hideDropdown(self) in self:HideDropdown() does NOT close the main dropdown if right clicked! Only for a left click... See ZO_ComboBox:HideDropdownInternal()
-	4. verify submenu anchors. Small adjustments not easily seen on small laptop monitor
+	2. Attention: zo_comboBox_base_hideDropdown(self) in self:HideDropdown() does NOT close the main dropdown if right clicked! Only for a left click... See ZO_ComboBox:HideDropdownInternal()
+	3. verify submenu anchors. Small adjustments not easily seen on small laptop monitor
 	- fired on handlers dropdown_OnShow dropdown_OnHide
-	5. Check if entries' .tooltip can be a function and then call that function and show it as normal ZO_Tooltips_ShowTextTooltip(control, text) instead of having to use .customTooltip for that
-
-
-	check divider entry.
-
-	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	Adjust header anchors to fit by sets
-
-	title
-	title, subtitle
-	title, subtitle, divider, filter
-	title, subtitle, divider, filter, custom control
-	title, subtitle, divider, custom control
-
-	subtitle
-	subtitle, divider, filter
-	subtitle, divider, filter, custom control
-	subtitle, divider, custom control
-
-	filter
-	filter, custom control
-	custom control
+	4. todo: Still a bug? Clicking a checkbox/button in a context menu's submenu closes the context menu
 
 
 -------------------
@@ -5466,15 +5455,10 @@ UPCOMING FEATURES  - What will be added in the future?
 -------------------
 	1. Sort headers for the dropdown (ascending/descending) (maybe: allowing custom sort functions too)
 	2. LibCustomMenu and ZO_Menu support in inventories
-
-	3. Collapsable filter container?
-		COllapsable may be difficult
-		It may require pushing the header bottom down when open and up when closed. Have not had much luck with resize to fit descendants
-		making it as a comboBox would not change the current dimminsions. And, it would add dificulties in passing the filter into the parent dropdown
 ]]
 
 --[[
-Placed here as a reminer to inspect how comboBox enabled is being handeled
+Placed here as a reminder to inspect how comboBox enabled is being handeled
 not to be confused with itemData.enabled
 
 function ZO_ComboBox_Base:SetEnabled(enabled)

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.31
-## AddOnVersion: 020301
+## Version: 2.32
+## AddOnVersion: 020302
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101043 101044

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -295,6 +295,7 @@
 							[headerControls.FILTER_CONTAINER] 	= filterContainer,
 							[headerControls.CUSTOM_CONTROL] 	= self:GetNamedChild("CustomControl"),
 							[headerControls.TOGGLE_BUTTON] 		= self:GetNamedChild("ToggleHeader"),
+							[headerControls.TOGGLE_BUTTON_CLICK_EXTENSION] 		= self:GetNamedChild("ToggleHeaderClickExtension"),
 						}
 						self:GetParent().header = self
 
@@ -565,6 +566,35 @@
 							<OnClicked>
 								ZO_Tooltips_HideTextTooltip()
 								ZO_CheckButton_OnClicked(self)
+							</OnClicked>
+						</Button>
+
+						<Button name="$(parent)ToggleHeaderClickExtension" inherits="ZO_ButtonBehaviorClickSound" hidden="true">
+							<DimensionConstraints minY="0" maxY="24" minX="0" />
+
+							<OnInitialized>
+								local owningWindow = self:GetOwningWindow()
+								owningWindow.toggleButtonClickExtension = self
+							</OnInitialized>
+
+							<OnMouseEnter>
+								local owningWindow = self:GetOwningWindow()
+								if owningWindow.object then
+									local toggleButton = owningWindow.toggleButton
+									owningWindow.object:ShowTextTooltip(self, BOTTOM, toggleButton:GetTooltipText(), owningWindow)
+								end
+							</OnMouseEnter>
+
+							<OnMouseExit>
+								ZO_Tooltips_HideTextTooltip()
+							</OnMouseExit>
+
+							<OnClicked>
+								ZO_Tooltips_HideTextTooltip()
+
+								local owningWindow = self:GetOwningWindow()
+								local toggleButton = owningWindow.toggleButton
+								ZO_CheckButton_OnClicked(toggleButton)
 							</OnClicked>
 						</Button>
 					</Controls>

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,7 +1,13 @@
--v- ---------------LSM v2.3 - 2024-08-25---------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-
+-[Additions]-
+-Added attribute ".doNotFilter boolean" to all entryTypes. If true then do not hide those controls if a search/filter is used
+  -> e.g. used for a button "Apply changes" at a submenu to apply checkboxes checked/unchecked state now even if search filter was hiding non-matching checkboxes
+-Changed collapsible header to expand if you click the whole header, and not only the small v^ button
+
+
+-v- ---------------LSM v2.31 - 2024-08-25---------------------------------------------------------------------------- -v-
 -[Fixes]-
 --Clicking a checkbox/button in a context menu's submenu closes the context menu
-
 
 -v- ---------------LSM v2.3 - 2024-08-19---------------------------------------------------------------------------- -v-
 -[Fixes]-


### PR DESCRIPTION
-Added entry.doNotFilter boolean to all entryTypes. If set to true these entries won't be hidden if the header's search / filter box is used and the name does not match. Used for e.g. button controls that should always show nevertheless if the name matches any search text
-Added a header's toggle button extension control to the left -> expand a collapsed header by clicking the total header, not only the small ^ button