### PR TITLE
Version 2 4 zo menu support

### DIFF
--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -620,7 +620,7 @@ d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollab
 				end,
 				buttonGroup = 3,
 				contextMenuCallback = function(...)
-					LibScrollableMenu.SetButtonGroupState(...)
+					LibScrollableMenu.ButtonGroupDefaultContextMenu(...)
 				end,
 			},
 			{
@@ -635,7 +635,7 @@ d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollab
 				buttonGroup = function() return 3 end,
 				buttonGroupOnSelectionChangedCallback = function(control, previousControl) d("checkbox group 3 selection changed callback!")  end,
 				rightClickCallback = function(...)
-					LibScrollableMenu.SetButtonGroupState(...)
+					LibScrollableMenu.ButtonGroupDefaultContextMenu(...)
 				end,
 			},
 			{

--- a/LibScrollableMenu/LibScrollableMenu-LAMSettings.lua
+++ b/LibScrollableMenu/LibScrollableMenu-LAMSettings.lua
@@ -17,7 +17,8 @@ local sv = lib.SV
 
 
 --Other libraries
-local LAM2 = LibAddonMenu2
+local LAM2 = lib.LAM2 or LibAddonMenu2
+
 
 ------------------------------------------------------------------------------------------------------------------------
 --LAM settings menu - local helper functions
@@ -82,6 +83,19 @@ function lib.BuildLAMSettingsMenu()
 			type = "description",
 			title = "Context menus",
 			text = "Test description here\n\ntest test test\n\n\nbla blubb",
+		},
+		{
+			type = "checkbox",
+			name = "Replace all ZO_Menu context menus",
+			tooltip = "Replace the context menus (ZO_Menu, LibCustomMenu) with LibScrolableMenu's scrollable context menu",
+			getFunc = function() return sv.ZO_MenuContextMenuReplacement end,
+			setFunc = function(checked)
+				--sv.ZO_MenuContextMenuReplacement = checked
+				lib.ContextMenuZO_MenuReplacement(checked, false) -- show chat output
+			end,
+			--disabled = function() return false end,
+			default = false,
+			reference = "LSM_LAM_CHECKBOX_REPLACE_ZO_MENU_CONTEXTMENUS"
 		},
         {
             type = "editbox",
@@ -176,7 +190,7 @@ function lib.BuildLAMSettingsMenu()
         {
             type = "dropdown",
 			name = "Already added owner names",
-			tooltip = "Choose an already added owner's controlName to change the values, or to delete it.",
+			tooltip = "Choose an already added owner's controlName to change the values, or to delete the saved values in total.",
 			choices = existingOwnerNamesList,
 			getFunc = function() return selectedExistingOwnerName end,
 			setFunc = function(selectedOwnerName)

--- a/LibScrollableMenu/LibScrollableMenu-LAMSettings.lua
+++ b/LibScrollableMenu/LibScrollableMenu-LAMSettings.lua
@@ -1,0 +1,236 @@
+--------------------------------------------------------------------
+-- LibScrollableMenu - Support for ZO_Menu (including LibCustomMenu)
+
+local lib = LibScrollableMenu
+if lib == nil then return end
+
+
+--local ZOs references
+local tos = tostring
+
+--Local libray references
+local MAJOR = lib.name
+
+local comboBoxDefaults = lib.comboBoxDefaults
+
+local sv = lib.SV
+
+
+--Other libraries
+local LAM2 = LibAddonMenu2
+
+------------------------------------------------------------------------------------------------------------------------
+--LAM settings menu - local helper functions
+------------------------------------------------------------------------------------------------------------------------
+local existingOwnerNamesList
+local function buildExistingOwnerNamesList()
+	local existingOwnerNamesListLoc = {}
+	sv = lib.SV
+	if sv and sv.contextMenuSettings ~= nil then
+		for ownerControlName, _ in pairs(sv.contextMenuSettings) do
+			existingOwnerNamesListLoc[#existingOwnerNamesListLoc + 1] = ownerControlName
+		end
+	end
+	return existingOwnerNamesListLoc
+end
+
+local function updateExistingOwerNamesList(noLAMControlUpdate)
+	noLAMControlUpdate = noLAMControlUpdate or false
+	existingOwnerNamesList = buildExistingOwnerNamesList()
+
+	if not noLAMControlUpdate then
+		if LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME ~= nil then
+			LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME:UpdateChoices(existingOwnerNamesList)
+		end
+	end
+end
+
+
+------------------------------------------------------------------------------------------------------------------------
+-- LibAddonMenu - Settings menu for LibScrollableMenu
+------------------------------------------------------------------------------------------------------------------------
+function lib.BuildLAMSettingsMenu()
+	LAM2 = LAM2 or LibAddonMenu2
+	if LAM2 == nil then return end
+
+	--Add the LAM settings menufor the library to e.g. control the default values for visibleRows of all contextMenus, or
+	--change those for contextMenu's ownerNames (e.g. the ZO_PlayerInventory)
+	local panelData = {
+		type = "panel",
+		name = MAJOR,
+		displayName = MAJOR,
+		author = lib.author,
+		version = lib.version,
+		slashCommand = "/lsmsettings",
+		registerForRefresh = true,
+		registerForDefaults = false,
+	}
+    local LSMLAMPanelName = MAJOR .. "_LAMSettings"
+
+	lib.LAMsettingsPanel = LAM2:RegisterAddonPanel(LSMLAMPanelName, panelData)
+	sv = lib.SV
+
+	local contextMenuOwnerControlName, selectedExistingOwnerName, newVisibleRowsForControlName, newVisibleRowsSubmenuForControlName
+	updateExistingOwerNamesList(true)
+
+	local optionsData = {
+		{
+			type = "header",
+			name = MAJOR,
+		},
+		{
+			type = "description",
+			title = "Context menus",
+			text = "Test description here\n\ntest test test\n\n\nbla blubb",
+		},
+        {
+            type = "editbox",
+            name = "Owner control name",
+            tooltip = "Enter here the control name of a context menu owner, e.g. ZO_PlayerInventory",
+            getFunc = function() return contextMenuOwnerControlName end,
+            setFunc = function(newValue)
+				contextMenuOwnerControlName = newValue
+				if contextMenuOwnerControlName ~= "" then
+					if _G[contextMenuOwnerControlName] == nil then
+						d("["..MAJOR.."]ERROR - Control " .. tos(contextMenuOwnerControlName) .." does not globally exist!")
+						contextMenuOwnerControlName = nil
+						selectedExistingOwnerName = nil
+						newVisibleRowsForControlName = nil
+						newVisibleRowsSubmenuForControlName = nil
+					else
+						newVisibleRowsForControlName = (sv.contextMenuSettings and sv.contextMenuSettings[contextMenuOwnerControlName] and sv.contextMenuSettings[contextMenuOwnerControlName]["visibleRows"]) or comboBoxDefaults.visibleRows
+						newVisibleRowsSubmenuForControlName = (sv.contextMenuSettings and sv.contextMenuSettings[contextMenuOwnerControlName] and sv.contextMenuSettings[contextMenuOwnerControlName]["visibleRowsSubmenu"]) or comboBoxDefaults.visibleRowsSubmenu
+					end
+				else
+					contextMenuOwnerControlName = nil
+					selectedExistingOwnerName = nil
+					newVisibleRowsForControlName = nil
+					newVisibleRowsSubmenuForControlName = nil
+				end
+			end,
+            disabled = function() return false end,
+			width = "full",
+			default = "",
+        },
+        {
+            type = "slider",
+            name = "Visible rows #",
+            tooltip = "Enter the number of visible rows at the contextmenu of the owner's controlName",
+            getFunc = function()
+				return newVisibleRowsForControlName or comboBoxDefaults.visibleRows
+			end,
+            setFunc = function(newValue)
+				newVisibleRowsForControlName = newValue
+            end,
+			step = 1,
+			min = 5,
+			max = 30,
+            disabled = function() return contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "" end,
+			width = "half",
+			default = comboBoxDefaults.visibleRows,
+        },
+        {
+            type = "slider",
+            name = "Visible rows #, submenus",
+            tooltip = "Enter the number of visible rows at the contextmenu's submenus of the owner's controlName",
+            getFunc = function()
+				return newVisibleRowsSubmenuForControlName or comboBoxDefaults.visibleRowsSubmenu
+			end,
+            setFunc = function(newValue)
+				newVisibleRowsSubmenuForControlName = newValue
+            end,
+			step = 1,
+			min = 5,
+			max = 30,
+            disabled = function() return contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "" end,
+			width = "half",
+			default = comboBoxDefaults.visibleRowsSubmenu,
+        },
+        {
+            type = "button",
+            name = "Apply visibleRows",
+            tooltip = "Change the visible rows and visible rows of the submenu for the entered context menu owner's controlName.",
+            func = function()
+				if contextMenuOwnerControlName ~= nil and (newVisibleRowsForControlName ~= nil or newVisibleRowsSubmenuForControlName ~= nil) then
+					--Add the savedvariables update of sv.contextMenuSettings[contextMenuOwnerControlName]
+					if newVisibleRowsForControlName ~= nil then
+						sv.contextMenuSettings = sv.contextMenuSettings or {}
+						sv.contextMenuSettings[contextMenuOwnerControlName] = sv.contextMenuSettings[contextMenuOwnerControlName] or {}
+						sv.contextMenuSettings[contextMenuOwnerControlName].visibleRows = newVisibleRowsForControlName
+					end
+					if newVisibleRowsSubmenuForControlName ~= nil then
+						sv.contextMenuSettings = sv.contextMenuSettings or {}
+						sv.contextMenuSettings[contextMenuOwnerControlName] = sv.contextMenuSettings[contextMenuOwnerControlName] or {}
+						sv.contextMenuSettings[contextMenuOwnerControlName].visibleRowsSubmenu = newVisibleRowsSubmenuForControlName
+					end
+					contextMenuOwnerControlName = nil
+					selectedExistingOwnerName = nil
+					newVisibleRowsForControlName = nil
+					newVisibleRowsSubmenuForControlName = nil
+
+					updateExistingOwerNamesList(false)
+				end
+			end,
+            disabled = function() return (contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "") or (newVisibleRowsForControlName == nil and newVisibleRowsSubmenuForControlName == nil) end,
+        },
+        {
+            type = "dropdown",
+			name = "Already added owner names",
+			tooltip = "Choose an already added owner's controlName to change the values, or to delete it.",
+			choices = existingOwnerNamesList,
+			getFunc = function() return selectedExistingOwnerName end,
+			setFunc = function(selectedOwnerName)
+				selectedExistingOwnerName = selectedOwnerName
+				contextMenuOwnerControlName = selectedOwnerName
+				newVisibleRowsForControlName = (sv.contextMenuSettings and sv.contextMenuSettings[selectedOwnerName] and sv.contextMenuSettings[selectedOwnerName]["visibleRows"]) or comboBoxDefaults.visibleRows
+				newVisibleRowsSubmenuForControlName = (sv.contextMenuSettings and sv.contextMenuSettings[selectedOwnerName] and sv.contextMenuSettings[selectedOwnerName]["visibleRowsSubmenu"]) or comboBoxDefaults.visibleRowsSubmenu
+				--[[
+				for ownerName, _ in pairs(sv.contextMenuSettings) do
+					if ownerName == selectedOwnerName then
+						selectedExistingOwnerName = selectedOwnerName
+						contextMenuOwnerControlName = selectedOwnerName
+                        break
+					end
+				end
+				]]
+			end,
+            scrollable = true,
+			width = "half",
+			default = function() return nil end,
+			reference = "LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME"
+        },
+        {
+            type = "button",
+            name = "Delete control name",
+            tooltip = "Delete the selected owner's controlName from the saved controls list",
+            func = function()
+				if selectedExistingOwnerName ~= nil then
+					if sv.contextMenuSettings and sv.contextMenuSettings[selectedExistingOwnerName] ~= nil then
+						sv.contextMenuSettings[selectedExistingOwnerName] = nil
+					end
+					selectedExistingOwnerName = nil
+					contextMenuOwnerControlName = nil
+					newVisibleRowsForControlName = nil
+					newVisibleRowsSubmenuForControlName = nil
+
+					updateExistingOwerNamesList(false)
+				end
+			end,
+            disabled = function() return selectedExistingOwnerName == nil or selectedExistingOwnerName == "" or contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "" or contextMenuOwnerControlName ~= selectedExistingOwnerName end,
+        },
+
+	}
+	LAM2:RegisterOptionControls(LSMLAMPanelName, optionsData)
+
+    local function openedPanel(panel)
+        if panel ~= lib.LAMsettingsPanel then return end
+
+		selectedExistingOwnerName = nil
+		contextMenuOwnerControlName = nil
+		newVisibleRowsForControlName = nil
+		newVisibleRowsSubmenuForControlName = nil
+
+		updateExistingOwerNamesList(false)
+    end
+    CALLBACK_MANAGER:RegisterCallback("LAM-PanelOpened", openedPanel)
+end

--- a/LibScrollableMenu/LibScrollableMenu-ZO_Menu.lua
+++ b/LibScrollableMenu/LibScrollableMenu-ZO_Menu.lua
@@ -754,7 +754,10 @@ local function addZO_Menu_ShowMenuHook()
 		if lib.debugLCM then d(">>> PostHooked ZO_CheckButton_SetUnChecked") end
 
 
-		--ZO_Menu's AddMenuitem function. Attention: Will be called internally by LibCustomMenu's AddCustom*MenuItem too!
+		--ZO_Menu's AddMenuItem function. It will be called for each added context menu item once.
+		--Attention: Will be called internally by LibCustomMenu's AddCustom*MenuItem too!
+		--Grab the added data here and transfer it to our internal tables, as mapped LSM entryType, via function storeZO_MenuItemDataForLSM.
+		---Also checks for checkboxes that were added before and prepares their current state update properly as this might happen after the AddMenuItem function was called
 		SecurePostHook("AddMenuItem", function(labelText, onSelect, itemType, labelFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled)
 			updateZO_MenuVariables()
 			ZOMenus:SetHidden(false)
@@ -822,7 +825,7 @@ local function addZO_Menu_ShowMenuHook()
 		if lib.debugLCM then d(">>> PostHooked AddMenuItem") end
 
 
-		--Hook the ClearMenu function so we can clear our LSM variables too
+		--Hook the ZO_Menu's ClearMenu function so we can clear our LSM variables too
 		SecurePostHook("ClearMenu", function()
 			if lib.debugLCM then
 				d("<<<<<<<<<<<<<<<<<<<<<<<")
@@ -835,6 +838,7 @@ local function addZO_Menu_ShowMenuHook()
 			clearCustomScrollableMenu()
 		end)
 		if lib.debugLCM then d(">>> PostHooked ClearMenu") end
+
 
 		--PreHook the ShowMenu function of ZO_Menu in order to map the ZO_Menu.items to the LSM entries
 		--and suppress the ZO_Menu to show -> Instead show LSM context menu
@@ -934,9 +938,10 @@ local function addZO_Menu_ShowMenuHook()
 				if lsmEntry ~= nil and lsmEntry.name ~= nil then
 					if lib.debugLCM then d("~~~~ Add item of ZO_Menu["..tos(idx).."]: " ..tos(lsmEntry.name)) end
 
-					--Transfer the menu entry now to LibScrollableMenu, instead of ZO_Menu
-					--->pass in lsmEntry as additionlData (last parameter) so m_normalColor etc. will be applied properly too
-					AddCustomScrollableMenuEntry(lsmEntry.name, lsmEntry.callback, lsmEntry.entryType, lsmEntry.entries, lsmEntry)
+					--Add the menu entry now to LibScrollableMenu's context menu, instead of ZO_Menu
+					--->pass in lsmEntry as additionlData (last parameter) so m_normalColor etc. will properly be applied to the entry too
+					local indexAdded, newEntry = AddCustomScrollableMenuEntry(lsmEntry.name, lsmEntry.callback, lsmEntry.entryType, lsmEntry.entries, lsmEntry)
+
 					numLSMItemsAddedDuringThisShowMenu = numLSMItemsAddedDuringThisShowMenu + 1
 				else
 					if lib.debugLCM then d("???? ERROR: item of ZO_Menu["..tos(idx).."] is nil, or got no name!") end

--- a/LibScrollableMenu/LibScrollableMenu-ZO_Menu.lua
+++ b/LibScrollableMenu/LibScrollableMenu-ZO_Menu.lua
@@ -4,6 +4,16 @@
 local lib = LibScrollableMenu
 if lib == nil then return end
 
+--Other libraries
+local LAM2 = lib.LAM2 or LibAddonMenu2
+local LCM = lib.LCM or LibCustomMenu
+
+--Local reference controls
+local ZOMenu = ZO_Menu
+local ZOMenus = ZO_Menus
+local ZOMenu_SetSelectedIndex = ZO_Menu_SetSelectedIndex
+local ZOMenuHighlight = ZO_MenuHighlight
+
 ------------------------------------------------------------------------------------------------------------------------
 -- Overview of what the ZO_Menu & LibCustomMenu integration does
 ------------------------------------------------------------------------------------------------------------------------
@@ -62,12 +72,12 @@ local LSM_ENTRY_TYPE_BUTTON = 		scrollListRowTypes["LSM_ENTRY_TYPE_BUTTON"]
 local LSM_ENTRY_TYPE_RADIOBUTTON = 	scrollListRowTypes["LSM_ENTRY_TYPE_RADIOBUTTON"]
 
 
---LibCustomMenu is loaded? If not these hooks will only take care of vanilla ZO_Menu
-local libCustomMenuIsLoaded = LibCustomMenu ~= nil
+--LibCustomMenu is loaded and provides the hookable functions (correct version <=722 was loaded)? If not the hooks will only take care of vanilla ZO_Menu!
+local libCustomMenuIsLoaded = (LCM ~= nil and LCM.AddMenuItem ~= nil and LCM.AddSubMenuItem ~= nil and true) or false
 
 --Mapping between LibCustomMenu and LibScrollableMenu's entry types at the context menus
 local mapLCMItemtypeToLSMEntryType
-if libCustomMenuIsLoaded then
+if libCustomMenuIsLoaded == true then
 	mapLCMItemtypeToLSMEntryType = {
 		[MENU_ADD_OPTION_LABEL]		= LSM_ENTRY_TYPE_NORMAL,
 		[MENU_ADD_OPTION_CHECKBOX]	= LSM_ENTRY_TYPE_CHECKBOX,
@@ -176,6 +186,13 @@ local LCM_AddItemFunctionsHooked = false
 --Local helper functions
 ------------------------------------------------------------------------------------------------------------------------
 
+local function updateZO_MenuVariables()
+	ZOMenu = 	ZOMenu or ZO_Menu
+	ZOMenus = 	ZOMenus or ZO_Menus
+	ZOMenu_SetSelectedIndex = ZO_Menu_SetSelectedIndex
+	ZOMenuHighlight = ZO_MenuHighlight
+end
+
 --Is the control allowed -> Means: Does this control use LSM for ZO_Menu/LCM entries?
 --> LSM will be used normally then
 local function isAllowedControl(owner)
@@ -247,29 +264,33 @@ end
 
 --Hide currently shown context menus, LSM and ZO_Menu/LSM
 local function clearZO_MenuAndLSM()
-	ZO_Menus:SetHidden(false)
+	updateZO_MenuVariables()
+	ZOMenus:SetHidden(false)
 	ClearMenu()
 	clearCustomScrollableMenu()
 end
 
 --Hide the ZO_Menu controls etc. but keep the index, owner and anchors etc. as they are
--->ZO_Menu.items should be valid then for other addons to read them until real ClearMenu() is called?
+-->ZOMenu.items should be valid then for other addons to read them until real ClearMenu() is called?
 local function customClearMenu()
-	ZO_Menu_SetSelectedIndex(nil)
+	updateZO_MenuVariables()
+	ZOMenu_SetSelectedIndex(nil)
 
-	ZO_Menu:ClearAnchors()
-	ZO_Menu:SetDimensions(0, 0)
-	ZO_Menu.width = 0
-	ZO_Menu.height = 0
-	ZO_Menu.spacing = 0
-	ZO_Menu.menuPad = 8
-	ZO_Menu:SetHidden(true)
-	ZO_MenuHighlight:SetHidden(true)
+	ZOMenu:ClearAnchors()
+	ZOMenu:SetDimensions(0, 0)
+	ZOMenu.width = 0
+	ZOMenu.height = 0
+	ZOMenu.spacing = 0
+	ZOMenu.menuPad = 8
+	ZOMenu:SetHidden(true)
+	ZOMenuHighlight:SetHidden(true)
 
 	--Hide the ZO_Menu TLC now -> to hide that small [ ] menu TLC near the right clicked mouse position
-	ZO_Menus:SetHidden(true)
+	ZOMenus:SetHidden(true)
 end
 
+--Clear all internally used LSM variables of the ZO_Menu item's mapping, preventer variables for SHowMenu and ClearMenu etc.
+--so that ZO_Menu and LibCustomMenu work normal again
 local function clearInternalZO_MenuToLSMMappingData()
 	if lib.debugLCM then d("["..MAJOR.."]clearInternalZO_MenuToLSMMappingData") end
 	LCMLastAddedMenuItem              = {}
@@ -341,774 +362,805 @@ end
 
 
 ------------------------------------------------------------------------------------------------------------------------
---Load the ZO_Menu hooks
+--The ZO_Menu hooks
 ------------------------------------------------------------------------------------------------------------------------
-function lib.LoadZO_MenuHooks()
-	--Map the LibCustomMenu and normal ZO_Menu entries data to LibScrollableMenu entries data
+--Map the LibCustomMenu and normal ZO_Menu entries data to LibScrollableMenu entries data
 
-	--======================================================================================================================
-	--Function to map the ZO_menu items to LSM entryType context menu items
-	-->Those will be called from function AddMenuItem, and then calls function storeZO_MenuItemDataForLSM and stores in table lib.ZO_MenuData[menuIndex]
-	--======================================================================================================================
-	local function mapZO_MenuItemToLSMEntry(ZO_MenuItemData, menuIndex, isBuildingSubmenu)
-		LSMAlreadyMappedItemNum = LSMAlreadyMappedItemNum + 1
-		if lib.debugLCM then
-			if isBuildingSubmenu == true then
-				d("-_-_-_-_- RECURSIVE CALL -_-_-_-_-")
-			end
-			d("[LSM]mapZO_MenuItemToLSMEntry-itemAddedNum: " .. tos(LSMAlreadyMappedItemNum) ..", isBuildingSubmenu: " .. tos(isBuildingSubmenu))
+--======================================================================================================================
+--Function to map the ZO_menu items to LSM entryType context menu items
+-->Those will be called from function AddMenuItem, and then calls function storeZO_MenuItemDataForLSM and stores in table lib.ZO_MenuData[menuIndex]
+--======================================================================================================================
+local function mapZO_MenuItemToLSMEntry(ZO_MenuItemData, menuIndex, isBuildingSubmenu)
+	updateZO_MenuVariables()
+	LSMAlreadyMappedItemNum = LSMAlreadyMappedItemNum + 1
+	if lib.debugLCM then
+		if isBuildingSubmenu == true then
+			d("-_-_-_-_- RECURSIVE CALL -_-_-_-_-")
 		end
-		isBuildingSubmenu = isBuildingSubmenu or false
-		local lsmEntry
-		local ZO_Menu_ItemCtrl = ZO_MenuItemData.item --~= nil and ZO_ShallowTableCopy(ZO_MenuItemData.item)
-		if ZO_Menu_ItemCtrl ~= nil then
-
-			local entryName
-			local callbackFunc
-			local checked
-			local isChecked = false
-			local isZO_MenuEntryHavingCheckbox = (ZO_MenuItemData.checkbox ~= nil and true) or false
-			--Is the item a checkbox control? Attention: ZO_Menu entries openign a submenu via LibCustomMenu sometimes got the ZO_MenuItemData.checkbox set -> somehow used internally in LCM to provide the submenu's arrow texture?
-			local isCheckbox = ((ZO_Menu_ItemCtrl.itemType == MENU_ADD_OPTION_CHECKBOX or isZO_MenuEntryHavingCheckbox) and true) or false
-			if isZO_MenuEntryHavingCheckbox == true then
-				--Get ZO_Menu's checkbox's current checked state
-				isChecked = ZO_CheckButton_IsChecked(ZO_MenuItemData.checkbox)
-			end
-			local isDivider = false
-			local isHeader = false
-			local entryType = (isCheckbox == true and LSM_ENTRY_TYPE_CHECKBOX) or LSM_ENTRY_TYPE_NORMAL
-			local hasSubmenu = false
-			local submenuEntries
-			local isNew = nil
-
-			local myfont
-			local normalColor
-			local highlightColor
-			local disabledColor
-			local itemYPad
-			local horizontalAlignment
-
-			--Tooltips
-			local tooltip
-			local customTooltip --LSM uses entry.customTooltip function to show any tooltip that was added for LCM
-			local enabled = true
-
-			--Flag for "Read values directly from a ZO_Menu item too"
-			local processVanillaZO_MenuItem = true
-
-
-			--Is the tooltip a function, or a string?
-			local tooltipData = ZO_Menu_ItemCtrl.tooltip
-			local tooltipIsFunction = type(tooltipData) == "function"
-
-			--Is LibCustomMenu loaded?
-			if libCustomMenuIsLoaded == true then
-				--LibCustomMenu values in ZO_Menu.items[i].item.entryData or .submenuData:
-				--[[
-				{
-					mytext = mytext,
-					myfunction = myfunction or function() end,
-					itemType = itemType,
-					myfont = myFont,
-					normalColor = normalColor,
-					highlightColor = highlightColor,
-					itemYPad = itemYPad,
-					horizontalAlignment = horizontalAlignment
-				}
-				]]
-				--Normal entry?
-				local entryData = ZO_Menu_ItemCtrl.entryData
-				--Is this an entry opening a submenu?
-				local submenuData = ZO_Menu_ItemCtrl.submenuData
-				local submenuItems = (submenuData ~= nil and submenuData.entries ~= nil and submenuData.entries) or nil
-				if lib.debugLCM then d(">entryData: " ..tos(entryData) .."; submenuData: " ..tos(submenuData) .."; #entries: " ..tos(submenuItems ~= nil and #submenuItems or 0)) end
-
-				-->LCM Submenu
-				if submenuData ~= nil and not ZO_IsTableEmpty(submenuItems) then
-					if lib.debugLCM then d(">LCM  found Submenu items: " ..tos(#submenuItems)) end
-					processVanillaZO_MenuItem = false
-
-					entryName = 			entryData.mytext
-					entryType = 			LSM_ENTRY_TYPE_NORMAL
-					callbackFunc = 			entryData.myfunction
-					myfont =				entryData.myfont
-					normalColor = 			entryData.normalColor
-					highlightColor = 		entryData.highlightColor
-					itemYPad = 				entryData.itemYPad
-					isHeader = 				false
-					tooltip = 				(not tooltipIsFunction and tooltipData) or nil
-					customTooltip = 		(tooltipIsFunction == true and tooltipData) or nil
-					--enabled =				submenuData.enabled Not supported in LibCustomMenu
-
-					hasSubmenu = true
-					--Add non-nested subMenu entries of LibCustomMenu (as LCM only can build 1 level submenus we do not need to nest more depth)
-					submenuEntries = {}
-					for submenuIdx, submenuEntry in ipairs(submenuItems) do
-						submenuEntry.submenuData = nil
-						--Prepapre the needed data table for the recursive call to mapZO_MenuItemToLSMEntry
-						-->Fill in "entryData" table into a DUMMY item
-						submenuEntry.entryData = {
-							mytext = 				submenuEntry.label or submenuEntry.name,
-							itemType =				submenuEntry.itemType,
-							myfunction =			submenuEntry.callback,
-							myfont =				submenuEntry.myfont,
-							normalColor =			submenuEntry.normalColor,
-							highlightColor =		submenuEntry.highlightColor,
-							itemYPad =				submenuEntry.itemYPad,
-							horizontalAlignment =	submenuEntry.horizontalAlignment,
-							enabled =				true,
-							checked = 				submenuEntry.checked,
-						}
-
-						local tooltipDataSubMenu = submenuEntry.tooltip
-						local tooltipIsFunctionSubMenu = type(tooltipDataSubMenu) == "function"
-						if tooltipIsFunctionSubMenu then
-							submenuEntry.entryData.customTooltip = tooltipDataSubMenu
-						else
-							submenuEntry.entryData.tooltip = tooltipDataSubMenu
-						end
-
-						if submenuEntry.disabled ~= nil then
-							local disabledType = type(submenuEntry.disabled)
-							if disabledType == "function" then
-								submenuEntry.entryData.enabled = function(...) return not submenuEntry.disabled(...) end
-							elseif disabledType == "boolean" then
-								submenuEntry.entryData.enabled = not submenuEntry.disabled
-							else
-							end
-						end
-
-						if lib.debugLCM then
-							local subMenuEntryCheckedState = getValueOrCallback(submenuEntry.entryData.checked, submenuEntry.entryData)
-							d(">>Submenu item-name: " ..tos(submenuEntry.entryData.mytext) .."; itemType: " ..tos(submenuEntry.entryData.itemType) .. "; checked: " .. tos(subMenuEntryCheckedState))
-						end
-
-						--Recursively call the same function here to map the submenu entries for LSM
-						local lsmEntryForSubmenu = mapZO_MenuItemToLSMEntry({ item = submenuEntry }, submenuIdx, true)
-						if lsmEntryForSubmenu ~= nil and lsmEntryForSubmenu.name ~= nil then
-							submenuEntries[#submenuEntries + 1] = lsmEntryForSubmenu
-						end
-					end
-
-				--> LCM normal entry
-				elseif entryData ~= nil then
-					entryName =				entryData.mytext
-					entryType = 			mapLCMItemtypeToLSMEntryType[entryData.itemType] or LSM_ENTRY_TYPE_NORMAL
-					callbackFunc = 			entryData.myfunction
-					myfont =				entryData.myfont
-					normalColor = 			entryData.normalColor
-					highlightColor = 		entryData.highlightColor
-					itemYPad = 				entryData.itemYPad
-					horizontalAlignment = 	entryData.horizontalAlignment
-
-					isHeader = 				(entryData.isHeader or (isHeader or ZO_Menu_ItemCtrl.isHeader)) or nil
-					checked =				(entryData.checked or (isCheckbox == true and isChecked)) or nil
-
-					tooltip = 				(entryData.tooltip or (not tooltipIsFunction and tooltipData)) or nil
-					customTooltip = 		(entryData.customTooltip or (tooltipIsFunction and tooltipData)) or nil
-
-					--Do we need to get additional data from ZO_Menu.items controls?
-					processVanillaZO_MenuItem = (entryName == nil or callbackFunc == nil and true) or false
-
-					if entryData.enabled ~= nil then
-						enabled = entryData.enabled
-					end
-
-					if lib.debugLCM then d(">LCM found normal item-processVanillaZO_MenuItem: " .. tos(processVanillaZO_MenuItem)) end
-				end
-			end
-
-			--Normal ZO_Menu item added via AddMenuItem (without LibCustomMenu, if with LCM but data was missig -> Fill up)
-			if processVanillaZO_MenuItem == true then
-				if lib.debugLCM then d(">LCM process vanilla ZO_Menu item") end
-				entryName = 	entryName or (ZO_Menu_ItemCtrl.nameLabel and ZO_Menu_ItemCtrl.nameLabel:GetText())
-				callbackFunc = 	callbackFunc or ZO_Menu_ItemCtrl.OnSelect
-				isHeader = 		isHeader or ZO_Menu_ItemCtrl.isHeader
-				tooltip = 		not tooltipIsFunction and tooltipData
-				customTooltip = tooltipIsFunction and tooltipData
-				checked = 		isCheckbox == true and isChecked or nil
-				if ZO_Menu_ItemCtrl.enabled ~= nil then
-					enabled = ZO_Menu_ItemCtrl.enabled
-				end
-			end
-
-			--Entry type checks
-			---Is the entry a divider "-"?
-			isDivider = (entryName and entryName == libDivider and true) or false
-			if isDivider then entryType = LSM_ENTRY_TYPE_DIVIDER end
-			---Is the entry a header?
-			if isHeader then entryType = LSM_ENTRY_TYPE_HEADER end
-
-
-			if lib.debugLCM then
-				d(">>LSM entry[" .. tos(LSMAlreadyMappedItemNum) .. "]-name: " ..tos(entryName) .. ", callbackFunc: " ..tos(callbackFunc) .. ", type: " ..tos(entryType) .. ", hasSubmenu: " .. tos(hasSubmenu) .. ", entries: " .. tos(submenuEntries))
-			end
-
-			--Return values for LSM entry
-			if entryName ~= nil then
-				lsmEntry = {}
-				lsmEntry.name = 			entryName
-				--lsmEntry.label = 			entryName -- only neede dif the label differs from the name. label = visible text, name = internal key and visible text if no label provided
-
-				lsmEntry.entryType = 		entryType
-				lsmEntry.isDivider = 		isDivider
-				lsmEntry.isHeader = 		isHeader
-				lsmEntry.checked = 			checked
-
-				lsmEntry.callback = 		callbackFunc
-
-				lsmEntry.hasSubmenu = 		hasSubmenu
-				lsmEntry.entries = 			submenuEntries
-
-				lsmEntry.tooltip = 			tooltip
-				lsmEntry.customTooltip =	customTooltip
-
-				lsmEntry.isNew = 			isNew
-
-				lsmEntry.m_font		= 		myfont or comboBoxDefaults.m_font
-				lsmEntry.m_normalColor = 	normalColor or comboBoxDefaults.m_normalColor
-				lsmEntry.m_disabledColor = 	disabledColor or comboBoxDefaults.m_disabledColor
-				lsmEntry.m_highlightColor = highlightColor or comboBoxDefaults.m_highlightColor
-
-				--TODO LSM 2.4 Add Support for those in LSM comboBoxDefaults etc.!
-				lsmEntry.m_itemYPad = 			 itemYPad or comboBoxDefaults.itemYPad
-				lsmEntry.m_horizontalAlignment = horizontalAlignment or comboBoxDefaults.horizontalAlignment
-
-				lsmEntry.enabled = 			enabled
-			end
-		elseif lib.debugLCM then
-			d("<ABORT: item data not found")
-		end
-		return lsmEntry
+		d("[LSM]mapZO_MenuItemToLSMEntry-itemAddedNum: " .. tos(LSMAlreadyMappedItemNum) ..", isBuildingSubmenu: " .. tos(isBuildingSubmenu))
 	end
-	lib.MapZO_MenuItemToLibScrollableMenuEntry = mapZO_MenuItemToLSMEntry
+	isBuildingSubmenu = isBuildingSubmenu or false
+	local lsmEntry
+	local ZO_Menu_ItemCtrl = ZO_MenuItemData.item --~= nil and ZO_ShallowTableCopy(ZO_MenuItemData.item)
+	if ZO_Menu_ItemCtrl ~= nil then
 
-
-	--======================================================================================================================
-	--Function to store ZO_Menu items data at lib.ZO_MenuData = {}, called from function AddMenuItem
-	--> uses the same index as ZO_Menu.items currently use. Will be directly mapped to LibScrollableMenu entries via function
-	--> mapZO_MenuItemToLSMEntry, and shown at ShowMenu() then
-	--======================================================================================================================
-	local function storeZO_MenuItemDataForLSM(index, mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled, entries, isDivider)
-		if lib.debugLCM then d("[LSM]storeLCMEntryDataToLSM-index: " ..tos(index) .."; mytext: " ..tos(mytext) .. "; entries: " .. tos(entries)) end
-
-		if index == nil or mytext == nil or lib.ZO_MenuData[index] ~= nil then
-			if lib.debugLCM then d("<ABORT index: " ..tos(index).. ", name: " ..mytext .. ", exists: " ..tos(lib.ZO_MenuData[index] ~= nil)) end
-			return
+		local entryName
+		local callbackFunc
+		local checked
+		local isChecked = false
+		local isZO_MenuEntryHavingCheckbox = (ZO_MenuItemData.checkbox ~= nil and true) or false
+		--Is the item a checkbox control? Attention: ZO_Menu entries openign a submenu via LibCustomMenu sometimes got the ZO_MenuItemData.checkbox set -> somehow used internally in LCM to provide the submenu's arrow texture?
+		local isCheckbox = ((ZO_Menu_ItemCtrl.itemType == MENU_ADD_OPTION_CHECKBOX or isZO_MenuEntryHavingCheckbox) and true) or false
+		if isZO_MenuEntryHavingCheckbox == true then
+			--Get ZO_Menu's checkbox's current checked state
+			isChecked = ZO_CheckButton_IsChecked(ZO_MenuItemData.checkbox)
 		end
+		local isDivider = false
+		local isHeader = false
+		local entryType = (isCheckbox == true and LSM_ENTRY_TYPE_CHECKBOX) or LSM_ENTRY_TYPE_NORMAL
+		local hasSubmenu = false
+		local submenuEntries
+		local isNew = nil
 
-		--Check if any ZO_Menu item was added, and get it's item's control
-		local lastAddedZO_MenuItem = ZO_Menu.items[index]
-		local lastAddedZO_MenuItemCtrl = (lastAddedZO_MenuItem ~= nil and lastAddedZO_MenuItem.item) or nil
-		if lastAddedZO_MenuItemCtrl ~= nil then
+		local myfont
+		local normalColor
+		local highlightColor
+		local disabledColor
+		local itemYPad
+		local horizontalAlignment
 
-			--Entry is a checkbox? Get current checked state
-			local isCheckbox = itemType == MENU_ADD_OPTION_CHECKBOX or lastAddedZO_MenuItem.checkbox ~= nil
-			local isChecked = false
-			if isCheckbox == true and lastAddedZO_MenuItem.checkbox ~= nil then
-				--Get ZO_Menu's checkbox's current checked state
-				isChecked = ZO_CheckButton_IsChecked(lastAddedZO_MenuItem.checkbox)
-				if lib.debugLCM then d("[LSM]storeZO_MenuItemDataForLSM - checkbox: " .. tos(getControlName(lastAddedZO_MenuItem.checkbox)) .. ", currentState: " .. tos(isChecked)) end
-			end
+		--Tooltips
+		local tooltip
+		local customTooltip --LSM uses entry.customTooltip function to show any tooltip that was added for LCM
+		local enabled = true
 
-			--Prepare the data table that should be mapped
-			local dataToAdd = {
-				["index"] = index,
-				["mytext"] = mytext,
-				["myfunction"] = myfunction,
-				["itemType"] = itemType,
-				["myFont"] = myFont,
-				["normalColor"] = normalColor,
-				["highlightColor"] = highlightColor,
-				["itemYPad"] = itemYPad,
-				["horizontalAlignment"] = horizontalAlignment,
-				["isHighlighted"] = isHighlighted,
-				["onEnter"] = onEnter,
-				["onExit"] = onExit,
-				["enabled"] = enabled,
-				["isDivider"] = isDivider,
-				["checked"] = isChecked,
-
-				["entries"] = entries,
-			}
-			lastAddedZO_MenuItem.item.entryData = dataToAdd
-			lastAddedZO_MenuItem.item.submenuData = (entries ~= nil and dataToAdd) or nil
-
-			--Map the entry of ZO_Menu to LSM entries now and add it to our internal ZO_MenuData table
-			local lsmEntryMapped = mapZO_MenuItemToLSMEntry(lastAddedZO_MenuItem, index, false)
-			if lsmEntryMapped ~= nil then
-				if lib.debugLCM then d(">>ADDED LSMEntryMapped, index: " ..tos(index) ..", name: " ..mytext) end
-				lib.ZO_MenuData[index] = lsmEntryMapped
-			end
-		elseif lib.debugLCM then
-			d("<ABORT 2: lastAddedZO_MenuItemCtrl is NIL")
-		end
-	end
+		--Flag for "Read values directly from a ZO_Menu item too"
+		local processVanillaZO_MenuItem = true
 
 
-	---- HOOKs ----
-	--Add a hook to the SHowMenu() function, if any addon registered a custom LSM replacement for ZO_menu via API function lib.RegisterZO_MenuContextMenuReplacement(addonName)
-	local function addZO_Menu_ShowMenuHook()
-		if lib.debugLCM then d("["..MAJOR.."]addZO_Menu_ShowMenuHook") end
-		if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return end
+		--Is the tooltip a function, or a string?
+		local tooltipData = ZO_Menu_ItemCtrl.tooltip
+		local tooltipIsFunction = type(tooltipData) == "function"
 
-		--LibCustomMenu is loaded?
+		--Is LibCustomMenu loaded?
 		if libCustomMenuIsLoaded == true then
-			--Check if LibCustomMenu hooks were done
-			if LCM_AddItemFunctionsHooked == true then return end
-			if lib.debugLCM then d("["..MAJOR.."]LibCustomMenu: Enabled / Applying hooks") end
+			--LibCustomMenu values in ZO_Menu.items[i].item.entryData or .submenuData:
+			--[[
+			{
+				mytext = mytext,
+				myfunction = myfunction or function() end,
+				itemType = itemType,
+				myfont = myFont,
+				normalColor = normalColor,
+				highlightColor = highlightColor,
+				itemYPad = itemYPad,
+				horizontalAlignment = horizontalAlignment
+			}
+			]]
+			--Normal entry?
+			local entryData = ZO_Menu_ItemCtrl.entryData
+			--Is this an entry opening a submenu?
+			local submenuData = ZO_Menu_ItemCtrl.submenuData
+			local submenuItems = (submenuData ~= nil and submenuData.entries ~= nil and submenuData.entries) or nil
+			if lib.debugLCM then d(">entryData: " ..tos(entryData) .."; submenuData: " ..tos(submenuData) .."; #entries: " ..tos(submenuItems ~= nil and #submenuItems or 0)) end
 
-			--Needed functions of LCM do not exist (wrong LCM version loaded)?
-			if LibCustomMenu.AddMenuItem ~= nil and LibCustomMenu.AddSubMenuItem ~= nil then
-				--LibCustomMenu.AddMenuItem(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled)
-				ZO_PreHook(LibCustomMenu, "AddMenuItem", function(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled)
-					LCMLastAddedMenuItem = {}
-					if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return false end
+			-->LCM Submenu
+			if submenuData ~= nil and not ZO_IsTableEmpty(submenuItems) then
+				if lib.debugLCM then d(">LCM  found Submenu items: " ..tos(#submenuItems)) end
+				processVanillaZO_MenuItem = false
 
-					--Add the entry to lib.ZO_MenuData = {} now
-					LCMLastAddedMenuItem = { index = ZO_Menu.currentIndex, name = mytext, callback = myfunction, itemType = itemType }
-					if lib.debugLCM then d("[LSM]PreHook LCM.AddMenuItem-name: " ..tos(mytext) .. "; itemType: " ..tos(itemType)) end
-				end)
-				--LibCustomMenu.AddSubMenuItem(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, entries, isDivider)
-				ZO_PreHook(LibCustomMenu, "AddSubMenuItem", function(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, entries, isDivider)
-					LCMLastAddedMenuItem = {}
-					if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return false end
+				entryName = 			entryData.mytext
+				entryType = 			LSM_ENTRY_TYPE_NORMAL
+				callbackFunc = 			entryData.myfunction
+				myfont =				entryData.myfont
+				normalColor = 			entryData.normalColor
+				highlightColor = 		entryData.highlightColor
+				itemYPad = 				entryData.itemYPad
+				isHeader = 				false
+				tooltip = 				(not tooltipIsFunction and tooltipData) or nil
+				customTooltip = 		(tooltipIsFunction == true and tooltipData) or nil
+				--enabled =				submenuData.enabled Not supported in LibCustomMenu
 
-					--Add the entry to lib.ZO_MenuData = {} now
-					LCMLastAddedMenuItem = { index = ZO_Menu.currentIndex, name = mytext, callback = myfunction, itemType = itemType, isSubmenu = true, entries = entries }
-					if lib.debugLCM then d("[LSM]PreHook LCM.AddSubMenuItem-name: " ..tos(mytext) .. "; entries: " ..tos(entries)) end
-				end)
+				hasSubmenu = true
+				--Add non-nested subMenu entries of LibCustomMenu (as LCM only can build 1 level submenus we do not need to nest more depth)
+				submenuEntries = {}
+				for submenuIdx, submenuEntry in ipairs(submenuItems) do
+					submenuEntry.submenuData = nil
+					--Prepapre the needed data table for the recursive call to mapZO_MenuItemToLSMEntry
+					-->Fill in "entryData" table into a DUMMY item
+					submenuEntry.entryData = {
+						mytext = 				submenuEntry.label or submenuEntry.name,
+						itemType =				submenuEntry.itemType,
+						myfunction =			submenuEntry.callback,
+						myfont =				submenuEntry.myfont,
+						normalColor =			submenuEntry.normalColor,
+						highlightColor =		submenuEntry.highlightColor,
+						itemYPad =				submenuEntry.itemYPad,
+						horizontalAlignment =	submenuEntry.horizontalAlignment,
+						enabled =				true,
+						checked = 				submenuEntry.checked,
+					}
 
-				--LibCustomMenu - Tooltip function hook to add the ZO_Menu.items[index].customTooltip function (if needed)
-				SecurePostHook("AddCustomMenuTooltip", function(tooltipFunc, index)
-					if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return false end
-					if type(tooltipFunc) ~= "function" then return end
-					index = index or #ZO_Menu.items
-					assert(index > 0 and index <= #ZO_Menu.items, "["..MAJOR.."]No ZO_Menu item found for the tooltip")
-					--Add the tooltip func as customTooltip to the mapped LSM entry now
-					local lsmEntry = lib.ZO_MenuData[index]
-					if lsmEntry == nil then return end
-					if lib.debugLCM then d("[LSM]AddCustomMenuTooltip-index: " ..tos(index) .. "; entry: " .. tos(lsmEntry.label or lsmEntry.name)) end
-					lsmEntry.tooltip = nil
-					lsmEntry.customTooltip = tooltipFunc
-				end)
-
-				--Hook the LibCustomMenu functions
-				LCM_AddItemFunctionsHooked = true
-			else
-				clearInternalZO_MenuToLSMMappingData()
-			end
-		end
-
-
-
-		--Check if ZO_Menu hooks were done
-		if ZO_Menu_showMenuHooked == false then
-			if lib.debugLCM then d("["..MAJOR.."]ZO_Menu / Applying hooks") end
-
-			--Checkboxes: If they were added to ZO_Menu via AddMenuItem - Monitor those so the first time they get checked/unchecked properly via the ZOs API functions
-			--they will update that value to the LSMentry too
-			-->e.g. if AddMenuItem returns the index for the entry of ZO_Menu and then you update it afterwards via ZO_CheckButton_SetChecked or ZO_CheckButton_SetUnchecked
-			local function checkIfZO_MenuCheckboxStateChanged(cBoxControl)
-				if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return end
-				local ZO_MenuIndexofCheckbox = lib.ZO_Menu_cBoxControlsToMonitor[cBoxControl]
-				if lib.debugLCM then d("[LSM]checkIfZO_MenuCheckboxStateChanged-ZO_MenuIndexofCheckbox: " ..tos(ZO_MenuIndexofCheckbox) .. "; name: " .. tos(getControlName(cBoxControl))) end
-				if cBoxControl == nil or ZO_MenuIndexofCheckbox == nil then return end
-				--Clear the monitored checkbox control from the table: Only update the checked state once
-				lib.ZO_Menu_cBoxControlsToMonitor[cBoxControl] = nil
-
-				--Get the mapped LSM entry of this checkbox
-				local lsmEntryForCheckbox = lib.ZO_MenuData[ZO_MenuIndexofCheckbox]
-				if lsmEntryForCheckbox == nil then return end
-
-				--PostHook here: Get the checkbox's current checked state
-				local isChecked = ZO_CheckButton_IsChecked(cBoxControl)
-				if isChecked == nil then return end
-
-				if lib.debugLCM then d(">>found LSMEntry, current checked state: " ..tos(getValueOrCallback(lsmEntryForCheckbox.checked)) .. ", newState: " .. tos(isChecked)) end
-				--If the LSMentry's .checked is nil or not a function (which would be run properly to update it's checked state), we set it manually now once
-				if type(lsmEntryForCheckbox.checked) ~= "function" then
-					lsmEntryForCheckbox.checked = isChecked
-				end
-			end
-			SecurePostHook("ZO_CheckButton_SetChecked", checkIfZO_MenuCheckboxStateChanged)
-			SecurePostHook("ZO_CheckButton_SetUnchecked", checkIfZO_MenuCheckboxStateChanged)
-			if lib.debugLCM then d(">>> PostHooked ZO_CheckButton_SetUnChecked") end
-
-
-			--ZO_Menu's AddMenuitem function. Attention: Will be called internally by LibCustomMenu's AddCustom*MenuItem too!
-			SecurePostHook("AddMenuItem", function(labelText, onSelect, itemType, labelFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled)
-				ZO_Menus:SetHidden(false)
-
-				--As we are in a PostHook: We need to get back to last index to compare it properly!
-				if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return end
-				lastAddedZO_MenuItemsIndex = ZO_Menu.currentIndex - 1
-				local lastAddedLCMEntryName = LCMLastAddedMenuItem ~= nil and LCMLastAddedMenuItem.name
-
-				if lib.debugLCM then d("[LSM]PostHook AddMenuItem-labelText: " ..tos(labelText) .. "; index: " ..tos(LCMLastAddedMenuItem.index) .."/last: " ..tos(lastAddedZO_MenuItemsIndex) .."; entries: " ..tos(LCMLastAddedMenuItem.entries)) end
-
-				--Was the item added via LibCustomMenu?
-				local entries
-				if libCustomMenuIsLoaded == true and lastAddedLCMEntryName ~= nil and LCMLastAddedMenuItem.index ~= nil  then
-
-					--Checkbox?
-					if LCMLastAddedMenuItem.itemType == MENU_ADD_OPTION_CHECKBOX then
-						--The checkbox's state might be updated "afer the AddMenuItem call" -> Which returns the ZO_Menu index for the checkbox row!
-						--So we need to get the state now via the same function that would check the state
-						--We assume functions ZO_CheckButton_SetChecked and ZO_CheckButton_SetUnchecked are used and the control passed in is the ZO_Menu.items[lastAddedIndex].checkbox.
-						--> So add that current cbox control to a list (ZO_MenucBoxControlsToMonitor) to check and SecurePostHook those functions (see above -> SecurePostHook("ZO_CheckButton_SetChecked", checkIfZO_MenuCheckboxStateChanged))
-						---> Check in them if the control passed in is our cbox here.
-						--> And then get it's "new actual" (posthook should have applied the new state already) state and update it in the LSMentry data afterwards:
-						--> As storeZO_MenuItemDataForLSM will be called directly after these line here it should add an entry to lib.ZO_MenuData[lastAddedIndex]
-						local cBoxControl = ZO_Menu.items[lastAddedZO_MenuItemsIndex].checkbox
-						if cBoxControl ~= nil then
-							if lib.debugLCM then d("[LSM]AddMenuItem-Added cbox control with index: "..tos(lastAddedZO_MenuItemsIndex) .. ", to ZO_Menu_cBoxControlsToMonitor") end
-							lib.ZO_Menu_cBoxControlsToMonitor[cBoxControl] = lastAddedZO_MenuItemsIndex
-						end
+					local tooltipDataSubMenu = submenuEntry.tooltip
+					local tooltipIsFunctionSubMenu = type(tooltipDataSubMenu) == "function"
+					if tooltipIsFunctionSubMenu then
+						submenuEntry.entryData.customTooltip = tooltipDataSubMenu
 					else
-						--Entry last added was a submenu?
-						if LCMLastAddedMenuItem.isSubmenu == true and LCMLastAddedMenuItem.entries ~= nil
-								and ( LCMLastAddedMenuItem.index == lastAddedZO_MenuItemsIndex
-								or ( lastAddedLCMEntryName == labelText or (labelText == string.format("%s |u16:0::|u", lastAddedLCMEntryName)) )
-						) and
-								LCMLastAddedMenuItem.callback == onSelect and LCMLastAddedMenuItem.itemType == itemType then
-							--Get a copy of the submenu entries added
-							entries = ZO_ShallowTableCopy(LCMLastAddedMenuItem.entries)
+						submenuEntry.entryData.tooltip = tooltipDataSubMenu
+					end
+
+					if submenuEntry.disabled ~= nil then
+						local disabledType = type(submenuEntry.disabled)
+						if disabledType == "function" then
+							submenuEntry.entryData.enabled = function(...) return not submenuEntry.disabled(...) end
+						elseif disabledType == "boolean" then
+							submenuEntry.entryData.enabled = not submenuEntry.disabled
+						else
 						end
 					end
 
-				end
-				LCMLastAddedMenuItem = {}
-
-				--Add the entry to lib.ZO_MenuData = {} now
-				local isDivider = (((libCustomMenuIsLoaded == true and itemType ~= MENU_ADD_OPTION_HEADER and labelText == libDivider) or labelText == libDivider) and true) or false
-
-				--Store the ZO_Menu/LCM last added entry to our LSM internal table now, with the mapped data to LSM context menu entry format
-				storeZO_MenuItemDataForLSM(lastAddedZO_MenuItemsIndex,
-						labelText,
-						onSelect,
-						itemType,
-						labelFont,
-						normalColor,
-						highlightColor,
-						itemYPad,
-						horizontalAlignment,
-						isHighlighted,
-						onEnter,
-						onExit,
-						enabled,
-						entries,
-						isDivider)
-			end)
-			if lib.debugLCM then d(">>> PostHooked AddMenuItem") end
-
-
-			--Hook the ClearMenu function so we can clear our LSM variables too
-			SecurePostHook("ClearMenu", function()
-				if lib.debugLCM then
-					d("<<<<<<<<<<<<<<<<<<<<<<<")
-					d("[LSM]ClearMenu - preventClearCustomScrollableMenuToClearZO_MenuData: " ..tos(lib.preventClearCustomScrollableMenuToClearZO_MenuData))
-					d("<<<<<<<<<<<<<<<<<<<<<<<")
-				end
-				ZO_Menus:SetHidden(false)
-
-				--Clear the existing LSM context menu entries
-				clearCustomScrollableMenu()
-			end)
-			if lib.debugLCM then d(">>> PostHooked ClearMenu") end
-
-			--PreHook the ShowMenu function of ZO_Menu in order to map the ZO_Menu.items to the LSM entries
-			--and suppress the ZO_Menu to show -> Instead show LSM context menu
-			-->Attention: ShowMenu will be called several times after another (e.g. first by ZOs vanilla code, then for EACH addon added menu entries)
-			---->Important: So we do must NOT call ClearMenu() or ClearCustomScrollableMenu() in between
-			--->One needs to "only add new entries added to ZO_Menu". Else we would re-add the before added entries which have been added via
-			--->AddCustomScrollableMenuEntry already
-			--->The currently last added entry index will be stored in lib.ZO_MenuData_CurrentIndex, and we will only add the "new added" (after that index)
-			--->entries of our table lib.ZO_MenuData to the current menu then
-			ZO_PreHook("ShowMenu", function(owner, initialRefCount, menuType)
-				--Unhide the TLC so the menus of ZO_Menu will show properly in any case
-				ZO_Menus:SetHidden(false)
-
-				--Should the ZO_Menu not close any opened LSM? e.g. to show the textSearchHistory at the LSM text filter search box
-				if lib.preventLSMClosingZO_Menu == true then
-					lib.preventLSMClosingZO_Menu = nil
-					return
-				end
-
-				--No LSM replacement for ZO_Menu is registered at all? Abort here now and show ZO_Menu normally
-				if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu()
-				end
-				if lib.debugLCM then
-					d("!!!!!!!!!!!!!!!!!!!!")
-					d("[LSM]ShowMenu - initialRefCount: " ..tos(initialRefCount) .. ", menuType: " ..tos(menuType))
-					d("!!!!!!!!!!!!!!!!!!!!")
-				end
-				--Any items to show in the ZO_Menu?
-				if next(ZO_Menu.items) == nil then
-					if lib.debugLCM then d("<ABORT: No ZO_Menu.items available") end
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu() -> Will return false in there directly then
-				end
-
-				--No entries added to internal LSM mapped enties table yet (nothing was available in ZO_Menu?) -> Show normal ZO_Menu.items data then
-				local ZO_MenuData = lib.ZO_MenuData
-				if ZO_IsTableEmpty(ZO_MenuData) then
-					if lib.debugLCM then d("<ABORT: No LSM.ZO_MenuData mapped entries available") end
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu()
-				end
-
-				--Do not support any non default menu types (e.g. dropdown special menus like ZO_AutoComplete)
-				menuType = menuType or MENU_TYPE_DEFAULT
-				if menuType ~= MENU_TYPE_DEFAULT then
-					if lib.debugLCM then d("<ABORT: Non supported menu type: " .. tos(menuType)) end
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu()
-				end
-
-				owner = owner or GetMenuOwner(ZO_Menu)
-				--No owner provided? Get the control below the mouse cursor
-				owner = owner or moc()
-				if owner == nil then
-					if lib.debugLCM then d("<ABORT: No menu owner determined") end
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu()
-				end
-
-				--Is the control allowed to exchange ZO_Menu? e.g. inventory context menu
-				local isAllowed, ownerName = isAllowedControl(owner)
-				if not isAllowed then
-					if lib.debugLCM then d("<ABORT: Menu owner " .. tos(ownerName) .. " is not allowed for LSM usage") end
-					resetZO_MenuClearVariables()
-					return false
-				end
-
-				--Is the control blocked?
-				local isBlocked = false
-				isBlocked, ownerName = isBlacklistedControl(owner, ownerName)
-				if isBlocked == true then
-					if lib.debugLCM then d("<ABORT: Menu owner " .. tos(ownerName) .. " is a blocked control") end
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu()
-				end
-
-				--Build new LSM context menu now
-				local numLSMItemsAddedDuringThisShowMenu = 0
-				--The last index added for an LSM entry in the current context menu (so we do not add the same entries again and again with each ShowMenu() call)
-				local lastUsedItemIndex                  = lib.ZO_MenuData_CurrentIndex
-
-				--for idx, lsmEntry in ipairs(lib.ZO_MenuData) do
-				local numItems = #ZO_MenuData
-				local startIndex = lastUsedItemIndex + 1
-				if startIndex > numItems then
-					if lib.debugLCM then d("<ABORT: startIndex "  ..tos(startIndex).." > numItems: " ..tos(numItems)) end
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu()
-				end
-
-				--Now loop all new added entries (> lib.ZO_MenuData_CurrentIndex) from ZO_MenuData and add them to the LSM context menu
-				for idx=startIndex, numItems, 1  do
-					local lsmEntry = ZO_MenuData[idx]
-
-					if lsmEntry ~= nil and lsmEntry.name ~= nil then
-						if lib.debugLCM then d("~~~~ Add item of ZO_Menu["..tos(idx).."]: " ..tos(lsmEntry.name)) end
-
-						--Transfer the menu entry now to LibScrollableMenu, instead of ZO_Menu
-						--->pass in lsmEntry as additionlData (last parameter) so m_normalColor etc. will be applied properly too
-						AddCustomScrollableMenuEntry(lsmEntry.name, lsmEntry.callback, lsmEntry.entryType, lsmEntry.entries, lsmEntry)
-						numLSMItemsAddedDuringThisShowMenu = numLSMItemsAddedDuringThisShowMenu + 1
-					else
-						if lib.debugLCM then d("???? ERROR: item of ZO_Menu["..tos(idx).."] is nil, or got no name!") end
+					if lib.debugLCM then
+						local subMenuEntryCheckedState = getValueOrCallback(submenuEntry.entryData.checked, submenuEntry.entryData)
+						d(">>Submenu item-name: " ..tos(submenuEntry.entryData.mytext) .."; itemType: " ..tos(submenuEntry.entryData.itemType) .. "; checked: " .. tos(subMenuEntryCheckedState))
 					end
 
-					--Set the last added index now, for next call to ShowMenu()
-					lib.ZO_MenuData_CurrentIndex = idx
+					--Recursively call the same function here to map the submenu entries for LSM
+					local lsmEntryForSubmenu = mapZO_MenuItemToLSMEntry({ item = submenuEntry }, submenuIdx, true)
+					if lsmEntryForSubmenu ~= nil and lsmEntryForSubmenu.name ~= nil then
+						submenuEntries[#submenuEntries + 1] = lsmEntryForSubmenu
+					end
 				end
 
-				--No LSM mapped items found? Show normal ZO_Menu now
-				if lib.debugLCM then d(">>> nummber of new added LSM items: " ..tos(numLSMItemsAddedDuringThisShowMenu)) end
-				if numLSMItemsAddedDuringThisShowMenu <= 0 then
-					resetZO_MenuClearVariables()
-					return false -- run original ZO_Menu's ShowMenu()
+			--> LCM normal entry
+			elseif entryData ~= nil then
+				entryName =				entryData.mytext
+				entryType = 			mapLCMItemtypeToLSMEntryType[entryData.itemType] or LSM_ENTRY_TYPE_NORMAL
+				callbackFunc = 			entryData.myfunction
+				myfont =				entryData.myfont
+				normalColor = 			entryData.normalColor
+				highlightColor = 		entryData.highlightColor
+				itemYPad = 				entryData.itemYPad
+				horizontalAlignment = 	entryData.horizontalAlignment
+
+				isHeader = 				(entryData.isHeader or (isHeader or ZO_Menu_ItemCtrl.isHeader)) or nil
+				checked =				(entryData.checked or (isCheckbox == true and isChecked)) or nil
+
+				tooltip = 				(entryData.tooltip or (not tooltipIsFunction and tooltipData)) or nil
+				customTooltip = 		(entryData.customTooltip or (tooltipIsFunction and tooltipData)) or nil
+
+				--Do we need to get additional data from ZO_Menu.items controls?
+				processVanillaZO_MenuItem = (entryName == nil or callbackFunc == nil and true) or false
+
+				if entryData.enabled ~= nil then
+					enabled = entryData.enabled
 				end
 
-				--Set the variable to call ClearMenu() on next reset of the LSM contextmenu (if LSM context menu closes e.g.)
-				lib.callZO_MenuClearMenuOnClearCustomScrollableMenu = true
-
-				--Hide original ZO_Menu (and LibCustomMenu added entries) now -> Do this here AFTER preparing LSM entries,
-				-- else the ZO_Menu.items and sub controls will be emptied already (nil)!
-				-->Important: Do NOT clear the ZO_Menu here!  Keep all entries in ZO_Menu.items. Entries with the same index
-				-->are skipped due to the usage of the index offset lib.ZO_MenuData_CurrentIndex!
-				--> So only visually "hide" the ZO_Menu here but do not call ClearMenu() as this would empty the ZO_Menu.items early!
-				customClearMenu()
-
-
-				--Show the LSM context menu now with the mapped and added ZO_Menu entries, in LSM format.
-				-->ShowCustomScrollableMenu will show all previously added entries plus the new ones
-				showLSMReplacmentContextMenuForZO_MenuNow(owner, ownerName)
-
-				--Hide the ZO_Menu TLC now -> Delayed to next frame (to hide that small [ ] menu TLC near the right clicked mouse position)
-				--> TODO: Moved to customClearMenu() function above. Test if that works
-				--[[
-				zo_callLater(function()
-					ZO_Menus:SetHidden(true)
-				end, 1)
-				]]
-
-				--Suppress original ZO_Menu building and "Show" LSM entries now (se above via ShowCustomScrollableMenu( ... ) )
-				return true
-			end)
-			if lib.debugLCM then d(">>> PreHooked ShowMenu") end
-
-			ZO_Menu_showMenuHooked = true
+				if lib.debugLCM then d(">LCM found normal item-processVanillaZO_MenuItem: " .. tos(processVanillaZO_MenuItem)) end
+			end
 		end
+
+		--Normal ZO_Menu item added via AddMenuItem (without LibCustomMenu, if with LCM but data was missig -> Fill up)
+		if processVanillaZO_MenuItem == true then
+			if lib.debugLCM then d(">LCM process vanilla ZO_Menu item") end
+			entryName = 	entryName or (ZO_Menu_ItemCtrl.nameLabel and ZO_Menu_ItemCtrl.nameLabel:GetText())
+			callbackFunc = 	callbackFunc or ZO_Menu_ItemCtrl.OnSelect
+			isHeader = 		isHeader or ZO_Menu_ItemCtrl.isHeader
+			tooltip = 		not tooltipIsFunction and tooltipData
+			customTooltip = tooltipIsFunction and tooltipData
+			checked = 		isCheckbox == true and isChecked or nil
+			if ZO_Menu_ItemCtrl.enabled ~= nil then
+				enabled = ZO_Menu_ItemCtrl.enabled
+			end
+		end
+
+		--Entry type checks
+		---Is the entry a divider "-"?
+		isDivider = (entryName and entryName == libDivider and true) or false
+		if isDivider then entryType = LSM_ENTRY_TYPE_DIVIDER end
+		---Is the entry a header?
+		if isHeader then entryType = LSM_ENTRY_TYPE_HEADER end
+
+
+		if lib.debugLCM then
+			d(">>LSM entry[" .. tos(LSMAlreadyMappedItemNum) .. "]-name: " ..tos(entryName) .. ", callbackFunc: " ..tos(callbackFunc) .. ", type: " ..tos(entryType) .. ", hasSubmenu: " .. tos(hasSubmenu) .. ", entries: " .. tos(submenuEntries))
+		end
+
+		--Return values for LSM entry
+		if entryName ~= nil then
+			lsmEntry = {}
+			lsmEntry.name = 			entryName
+			--lsmEntry.label = 			entryName -- only neede dif the label differs from the name. label = visible text, name = internal key and visible text if no label provided
+
+			lsmEntry.entryType = 		entryType
+			lsmEntry.isDivider = 		isDivider
+			lsmEntry.isHeader = 		isHeader
+			lsmEntry.checked = 			checked
+
+			lsmEntry.callback = 		callbackFunc
+
+			lsmEntry.hasSubmenu = 		hasSubmenu
+			lsmEntry.entries = 			submenuEntries
+
+			lsmEntry.tooltip = 			tooltip
+			lsmEntry.customTooltip =	customTooltip
+
+			lsmEntry.isNew = 			isNew
+
+			lsmEntry.m_font		= 		myfont or comboBoxDefaults.m_font
+			lsmEntry.m_normalColor = 	normalColor or comboBoxDefaults.m_normalColor
+			lsmEntry.m_disabledColor = 	disabledColor or comboBoxDefaults.m_disabledColor
+			lsmEntry.m_highlightColor = highlightColor or comboBoxDefaults.m_highlightColor
+
+			--TODO LSM 2.4 Add Support for those in LSM comboBoxDefaults etc.!
+			lsmEntry.m_itemYPad = 			 itemYPad or comboBoxDefaults.itemYPad
+			lsmEntry.m_horizontalAlignment = horizontalAlignment or comboBoxDefaults.horizontalAlignment
+
+			lsmEntry.enabled = 			enabled
+		end
+	elseif lib.debugLCM then
+		d("<ABORT: item data not found")
+	end
+	return lsmEntry
+end
+lib.MapZO_MenuItemToLibScrollableMenuEntry = mapZO_MenuItemToLSMEntry
+
+
+--======================================================================================================================
+--Function to store ZO_Menu items data at lib.ZO_MenuData = {}, called from function AddMenuItem
+--> uses the same index as ZO_Menu.items currently use. Will be directly mapped to LibScrollableMenu entries via function
+--> mapZO_MenuItemToLSMEntry, and shown at ShowMenu() then
+--======================================================================================================================
+local function storeZO_MenuItemDataForLSM(index, mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled, entries, isDivider)
+	if lib.debugLCM then d("[LSM]storeLCMEntryDataToLSM-index: " ..tos(index) .."; mytext: " ..tos(mytext) .. "; entries: " .. tos(entries)) end
+
+	if index == nil or mytext == nil or lib.ZO_MenuData[index] ~= nil then
+		if lib.debugLCM then d("<ABORT index: " ..tos(index).. ", name: " ..mytext .. ", exists: " ..tos(lib.ZO_MenuData[index] ~= nil)) end
+		return
+	end
+
+	--Check if any ZO_Menu item was added, and get it's item's control
+	local lastAddedZO_MenuItem = ZOMenu.items[index]
+	local lastAddedZO_MenuItemCtrl = (lastAddedZO_MenuItem ~= nil and lastAddedZO_MenuItem.item) or nil
+	if lastAddedZO_MenuItemCtrl ~= nil then
+
+		--Entry is a checkbox? Get current checked state
+		local isCheckbox = itemType == MENU_ADD_OPTION_CHECKBOX or lastAddedZO_MenuItem.checkbox ~= nil
+		local isChecked = false
+		if isCheckbox == true and lastAddedZO_MenuItem.checkbox ~= nil then
+			--Get ZO_Menu's checkbox's current checked state
+			isChecked = ZO_CheckButton_IsChecked(lastAddedZO_MenuItem.checkbox)
+			if lib.debugLCM then d("[LSM]storeZO_MenuItemDataForLSM - checkbox: " .. tos(getControlName(lastAddedZO_MenuItem.checkbox)) .. ", currentState: " .. tos(isChecked)) end
+		end
+
+		--Prepare the data table that should be mapped
+		local dataToAdd = {
+			["index"] = index,
+			["mytext"] = mytext,
+			["myfunction"] = myfunction,
+			["itemType"] = itemType,
+			["myFont"] = myFont,
+			["normalColor"] = normalColor,
+			["highlightColor"] = highlightColor,
+			["itemYPad"] = itemYPad,
+			["horizontalAlignment"] = horizontalAlignment,
+			["isHighlighted"] = isHighlighted,
+			["onEnter"] = onEnter,
+			["onExit"] = onExit,
+			["enabled"] = enabled,
+			["isDivider"] = isDivider,
+			["checked"] = isChecked,
+
+			["entries"] = entries,
+		}
+		lastAddedZO_MenuItem.item.entryData = dataToAdd
+		lastAddedZO_MenuItem.item.submenuData = (entries ~= nil and dataToAdd) or nil
+
+		--Map the entry of ZO_Menu to LSM entries now and add it to our internal ZO_MenuData table
+		local lsmEntryMapped = mapZO_MenuItemToLSMEntry(lastAddedZO_MenuItem, index, false)
+		if lsmEntryMapped ~= nil then
+			if lib.debugLCM then d(">>ADDED LSMEntryMapped, index: " ..tos(index) ..", name: " ..mytext) end
+			lib.ZO_MenuData[index] = lsmEntryMapped
+		end
+	elseif lib.debugLCM then
+		d("<ABORT 2: lastAddedZO_MenuItemCtrl is NIL")
+	end
+end
+
+
+---- HOOKs ----
+--Add a hook to the SHowMenu() function, if any addon registered a custom LSM replacement for ZO_menu via API function lib.RegisterZO_MenuContextMenuReplacement(addonName)
+local function addZO_Menu_ShowMenuHook()
+	if lib.debugLCM then d("["..MAJOR.."]addZO_Menu_ShowMenuHook") end
+	updateZO_MenuVariables()
+	if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return end
+
+	--LibCustomMenu is loaded with the hookable functions?
+	if libCustomMenuIsLoaded == true then
+		--Check if LibCustomMenu hooks were done
+		if LCM_AddItemFunctionsHooked == true then return end
+		if lib.debugLCM then d("["..MAJOR.."]LibCustomMenu: Enabled / Applying hooks") end
+
+		--Needed functions of LCM do not exist (wrong LCM version loaded)?
+		--LibCustomMenu.AddMenuItem(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled)
+		ZO_PreHook(LCM, "AddMenuItem", function(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled)
+			LCMLastAddedMenuItem = {}
+			if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return false end
+
+			--Add the entry to lib.ZO_MenuData = {} now
+			LCMLastAddedMenuItem = { index = ZOMenu.currentIndex, name = mytext, callback = myfunction, itemType = itemType }
+			if lib.debugLCM then d("[LSM]PreHook LCM.AddMenuItem-name: " ..tos(mytext) .. "; itemType: " ..tos(itemType)) end
+		end)
+		--LibCustomMenu.AddSubMenuItem(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, entries, isDivider)
+		ZO_PreHook(LCM, "AddSubMenuItem", function(mytext, myfunction, itemType, myFont, normalColor, highlightColor, itemYPad, entries, isDivider)
+			LCMLastAddedMenuItem = {}
+			if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return false end
+
+			--Add the entry to lib.ZO_MenuData = {} now
+			LCMLastAddedMenuItem = { index = ZOMenu.currentIndex, name = mytext, callback = myfunction, itemType = itemType, isSubmenu = true, entries = entries }
+			if lib.debugLCM then d("[LSM]PreHook LCM.AddSubMenuItem-name: " ..tos(mytext) .. "; entries: " ..tos(entries)) end
+		end)
+
+		--LibCustomMenu - Tooltip function hook to add the ZO_Menu.items[index].customTooltip function (if needed)
+		SecurePostHook("AddCustomMenuTooltip", function(tooltipFunc, index)
+			if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return false end
+			if type(tooltipFunc) ~= "function" then return end
+			index = index or #ZOMenu.items
+			assert(index > 0 and index <= #ZOMenu.items, "["..MAJOR.."]No ZO_Menu item found for the tooltip")
+			--Add the tooltip func as customTooltip to the mapped LSM entry now
+			local lsmEntry = lib.ZO_MenuData[index]
+			if lsmEntry == nil then return end
+			if lib.debugLCM then d("[LSM]AddCustomMenuTooltip-index: " ..tos(index) .. "; entry: " .. tos(lsmEntry.label or lsmEntry.name)) end
+			lsmEntry.tooltip = nil
+			lsmEntry.customTooltip = tooltipFunc
+		end)
+
+		--Hook the LibCustomMenu functions
+		LCM_AddItemFunctionsHooked = true
 	end
 
 
-	--------------------------------------------------------------------------------------------------------------------
-	-- API functions for ZO_Menu hooks of LSM
-	--------------------------------------------------------------------------------------------------------------------
 
-	--Similar to LibCustomMenu: Register a hook for your addon to use LibScrollableMenu for the context menus
-	-->If ANY CustomScrollableContextMenu was registered with LibScrollableMenu:
-	-->LibCustomMenu and vanilla ZO_Menu context menus will be suppressed then, mapped into LSM entries and
-	-->LSM context menu will be shown instead
-	-->Else: Normal ZO_Menu and LibCustomMenu context menus will be used
-	function lib.RegisterZO_MenuContextMenuReplacement(addonName)
-		assert(addonName ~= nil and registeredCustomScrollableContextMenus[addonName] == nil, sfor('['..MAJOR..'.RegisterZO_MenuContextMenuReplacement] \'addonName\' missing or already registered: %q', tos(addonName)))
-		registeredCustomScrollableContextMenus[addonName] = true
-		clearZO_MenuAndLSM()
-		--Check if the ZO_Menu hooks need to be applied
-		addZO_Menu_ShowMenuHook()
-	end
-	local registerZO_MenuContextMenuReplacement = lib.RegisterZO_MenuContextMenuReplacement
+	--Check if ZO_Menu hooks were done
+	if ZO_Menu_showMenuHooked == false then
+		if lib.debugLCM then d("["..MAJOR.."]ZO_Menu / Applying hooks") end
 
+		--Checkboxes: If they were added to ZO_Menu via AddMenuItem - Monitor those so the first time they get checked/unchecked properly via the ZOs API functions
+		--they will update that value to the LSMentry too
+		-->e.g. if AddMenuItem returns the index for the entry of ZO_Menu and then you update it afterwards via ZO_CheckButton_SetChecked or ZO_CheckButton_SetUnchecked
+		local function checkIfZO_MenuCheckboxStateChanged(cBoxControl)
+			if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return end
+			local ZO_MenuIndexofCheckbox = lib.ZO_Menu_cBoxControlsToMonitor[cBoxControl]
+			if lib.debugLCM then d("[LSM]checkIfZO_MenuCheckboxStateChanged-ZO_MenuIndexofCheckbox: " ..tos(ZO_MenuIndexofCheckbox) .. "; name: " .. tos(getControlName(cBoxControl))) end
+			if cBoxControl == nil or ZO_MenuIndexofCheckbox == nil then return end
+			--Clear the monitored checkbox control from the table: Only update the checked state once
+			lib.ZO_Menu_cBoxControlsToMonitor[cBoxControl] = nil
 
-	--Unregister a before registered custom scrollable context menu again
-	--Returns true if addon was unregistered, false if addon was not unregistered
-	function lib.UnregisterZO_MenuContextMenuReplacement(addonName)
-		if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then
-			resetZO_MenuClearVariables()
-			return
+			--Get the mapped LSM entry of this checkbox
+			local lsmEntryForCheckbox = lib.ZO_MenuData[ZO_MenuIndexofCheckbox]
+			if lsmEntryForCheckbox == nil then return end
+
+			--PostHook here: Get the checkbox's current checked state
+			local isChecked = ZO_CheckButton_IsChecked(cBoxControl)
+			if isChecked == nil then return end
+
+			if lib.debugLCM then d(">>found LSMEntry, current checked state: " ..tos(getValueOrCallback(lsmEntryForCheckbox.checked)) .. ", newState: " .. tos(isChecked)) end
+			--If the LSMentry's .checked is nil or not a function (which would be run properly to update it's checked state), we set it manually now once
+			if type(lsmEntryForCheckbox.checked) ~= "function" then
+				lsmEntryForCheckbox.checked = isChecked
+			end
 		end
-		assert(addonName ~= nil, sfor('['..MAJOR..'.UnregisterZO_MenuContextMenuReplacement] \'addonName\' missing: %q', tos(addonName)))
-		if registeredCustomScrollableContextMenus[addonName] ~= nil then
-			registeredCustomScrollableContextMenus[addonName] = nil
-			clearZO_MenuAndLSM()
+		SecurePostHook("ZO_CheckButton_SetChecked", checkIfZO_MenuCheckboxStateChanged)
+		SecurePostHook("ZO_CheckButton_SetUnchecked", checkIfZO_MenuCheckboxStateChanged)
+		if lib.debugLCM then d(">>> PostHooked ZO_CheckButton_SetUnChecked") end
+
+
+		--ZO_Menu's AddMenuitem function. Attention: Will be called internally by LibCustomMenu's AddCustom*MenuItem too!
+		SecurePostHook("AddMenuItem", function(labelText, onSelect, itemType, labelFont, normalColor, highlightColor, itemYPad, horizontalAlignment, isHighlighted, onEnter, onExit, enabled)
+			updateZO_MenuVariables()
+			ZOMenus:SetHidden(false)
+
+			--As we are in a PostHook: We need to get back to last index to compare it properly!
+			if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then clearInternalZO_MenuToLSMMappingData() return end
+			lastAddedZO_MenuItemsIndex = ZOMenu.currentIndex - 1
+			local lastAddedLCMEntryName = LCMLastAddedMenuItem ~= nil and LCMLastAddedMenuItem.name
+
+			if lib.debugLCM then d("[LSM]PostHook AddMenuItem-labelText: " ..tos(labelText) .. "; index: " ..tos(LCMLastAddedMenuItem.index) .."/last: " ..tos(lastAddedZO_MenuItemsIndex) .."; entries: " ..tos(LCMLastAddedMenuItem.entries)) end
+
+			--Was the item added via LibCustomMenu?
+			local entries
+			if libCustomMenuIsLoaded == true and lastAddedLCMEntryName ~= nil and LCMLastAddedMenuItem.index ~= nil  then
+
+				--Checkbox?
+				if LCMLastAddedMenuItem.itemType == MENU_ADD_OPTION_CHECKBOX then
+					--The checkbox's state might be updated "afer the AddMenuItem call" -> Which returns the ZO_Menu index for the checkbox row!
+					--So we need to get the state now via the same function that would check the state
+					--We assume functions ZO_CheckButton_SetChecked and ZO_CheckButton_SetUnchecked are used and the control passed in is the ZO_Menu.items[lastAddedIndex].checkbox.
+					--> So add that current cbox control to a list (ZO_MenucBoxControlsToMonitor) to check and SecurePostHook those functions (see above -> SecurePostHook("ZO_CheckButton_SetChecked", checkIfZO_MenuCheckboxStateChanged))
+					---> Check in them if the control passed in is our cbox here.
+					--> And then get it's "new actual" (posthook should have applied the new state already) state and update it in the LSMentry data afterwards:
+					--> As storeZO_MenuItemDataForLSM will be called directly after these line here it should add an entry to lib.ZO_MenuData[lastAddedIndex]
+					local cBoxControl = ZOMenu.items[lastAddedZO_MenuItemsIndex].checkbox
+					if cBoxControl ~= nil then
+						if lib.debugLCM then d("[LSM]AddMenuItem-Added cbox control with index: "..tos(lastAddedZO_MenuItemsIndex) .. ", to ZO_Menu_cBoxControlsToMonitor") end
+						lib.ZO_Menu_cBoxControlsToMonitor[cBoxControl] = lastAddedZO_MenuItemsIndex
+					end
+				else
+					--Entry last added was a submenu?
+					if LCMLastAddedMenuItem.isSubmenu == true and LCMLastAddedMenuItem.entries ~= nil
+							and ( LCMLastAddedMenuItem.index == lastAddedZO_MenuItemsIndex
+							or ( lastAddedLCMEntryName == labelText or (labelText == string.format("%s |u16:0::|u", lastAddedLCMEntryName)) )
+					) and
+							LCMLastAddedMenuItem.callback == onSelect and LCMLastAddedMenuItem.itemType == itemType then
+						--Get a copy of the submenu entries added
+						entries = ZO_ShallowTableCopy(LCMLastAddedMenuItem.entries)
+					end
+				end
+
+			end
+			LCMLastAddedMenuItem = {}
+
+			--Add the entry to lib.ZO_MenuData = {} now
+			local isDivider = (((libCustomMenuIsLoaded == true and itemType ~= MENU_ADD_OPTION_HEADER and labelText == libDivider) or labelText == libDivider) and true) or false
+
+			--Store the ZO_Menu/LCM last added entry to our LSM internal table now, with the mapped data to LSM context menu entry format
+			storeZO_MenuItemDataForLSM(lastAddedZO_MenuItemsIndex,
+					labelText,
+					onSelect,
+					itemType,
+					labelFont,
+					normalColor,
+					highlightColor,
+					itemYPad,
+					horizontalAlignment,
+					isHighlighted,
+					onEnter,
+					onExit,
+					enabled,
+					entries,
+					isDivider)
+		end)
+		if lib.debugLCM then d(">>> PostHooked AddMenuItem") end
+
+
+		--Hook the ClearMenu function so we can clear our LSM variables too
+		SecurePostHook("ClearMenu", function()
+			if lib.debugLCM then
+				d("<<<<<<<<<<<<<<<<<<<<<<<")
+				d("[LSM]ClearMenu - preventClearCustomScrollableMenuToClearZO_MenuData: " ..tos(lib.preventClearCustomScrollableMenuToClearZO_MenuData))
+				d("<<<<<<<<<<<<<<<<<<<<<<<")
+			end
+			ZOMenus:SetHidden(false)
+
+			--Clear the existing LSM context menu entries
+			clearCustomScrollableMenu()
+		end)
+		if lib.debugLCM then d(">>> PostHooked ClearMenu") end
+
+		--PreHook the ShowMenu function of ZO_Menu in order to map the ZO_Menu.items to the LSM entries
+		--and suppress the ZO_Menu to show -> Instead show LSM context menu
+		-->Attention: ShowMenu will be called several times after another (e.g. first by ZOs vanilla code, then for EACH addon added menu entries)
+		---->Important: So we do must NOT call ClearMenu() or ClearCustomScrollableMenu() in between
+		--->One needs to "only add new entries added to ZO_Menu". Else we would re-add the before added entries which have been added via
+		--->AddCustomScrollableMenuEntry already
+		--->The currently last added entry index will be stored in lib.ZO_MenuData_CurrentIndex, and we will only add the "new added" (after that index)
+		--->entries of our table lib.ZO_MenuData to the current menu then
+		ZO_PreHook("ShowMenu", function(owner, initialRefCount, menuType)
+			--Unhide the TLC so the menus of ZO_Menu will show properly in any case
+			ZOMenus:SetHidden(false)
+
+			--Should the ZO_Menu not close any opened LSM? e.g. to show the textSearchHistory at the LSM text filter search box
+			if lib.preventLSMClosingZO_Menu == true then
+				lib.preventLSMClosingZO_Menu = nil
+				return
+			end
+
+			--No LSM replacement for ZO_Menu is registered at all? Abort here now and show ZO_Menu normally
+			if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu()
+			end
+			if lib.debugLCM then
+				d("!!!!!!!!!!!!!!!!!!!!")
+				d("[LSM]ShowMenu - initialRefCount: " ..tos(initialRefCount) .. ", menuType: " ..tos(menuType))
+				d("!!!!!!!!!!!!!!!!!!!!")
+			end
+			--Any items to show in the ZO_Menu?
+			if next(ZOMenu.items) == nil then
+				if lib.debugLCM then d("<ABORT: No ZO_Menu.items available") end
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu() -> Will return false in there directly then
+			end
+
+			--No entries added to internal LSM mapped enties table yet (nothing was available in ZO_Menu?) -> Show normal ZO_Menu.items data then
+			local ZO_MenuData = lib.ZO_MenuData
+			if ZO_IsTableEmpty(ZO_MenuData) then
+				if lib.debugLCM then d("<ABORT: No LSM.ZO_MenuData mapped entries available") end
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu()
+			end
+
+			--Do not support any non default menu types (e.g. dropdown special menus like ZO_AutoComplete)
+			menuType = menuType or MENU_TYPE_DEFAULT
+			if menuType ~= MENU_TYPE_DEFAULT then
+				if lib.debugLCM then d("<ABORT: Non supported menu type: " .. tos(menuType)) end
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu()
+			end
+
+			owner = owner or GetMenuOwner(ZOMenu)
+			--No owner provided? Get the control below the mouse cursor
+			owner = owner or moc()
+			if owner == nil then
+				if lib.debugLCM then d("<ABORT: No menu owner determined") end
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu()
+			end
+
+			--Is the control allowed to exchange ZO_Menu? e.g. inventory context menu
+			local isAllowed, ownerName = isAllowedControl(owner)
+			if not isAllowed then
+				if lib.debugLCM then d("<ABORT: Menu owner " .. tos(ownerName) .. " is not allowed for LSM usage") end
+				resetZO_MenuClearVariables()
+				return false
+			end
+
+			--Is the control blocked?
+			local isBlocked = false
+			isBlocked, ownerName = isBlacklistedControl(owner, ownerName)
+			if isBlocked == true then
+				if lib.debugLCM then d("<ABORT: Menu owner " .. tos(ownerName) .. " is a blocked control") end
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu()
+			end
+
+			--Build new LSM context menu now
+			local numLSMItemsAddedDuringThisShowMenu = 0
+			--The last index added for an LSM entry in the current context menu (so we do not add the same entries again and again with each ShowMenu() call)
+			local lastUsedItemIndex                  = lib.ZO_MenuData_CurrentIndex
+
+			--for idx, lsmEntry in ipairs(lib.ZO_MenuData) do
+			local numItems = #ZO_MenuData
+			local startIndex = lastUsedItemIndex + 1
+			if startIndex > numItems then
+				if lib.debugLCM then d("<ABORT: startIndex "  ..tos(startIndex).." > numItems: " ..tos(numItems)) end
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu()
+			end
+
+			--Now loop all new added entries (> lib.ZO_MenuData_CurrentIndex) from ZO_MenuData and add them to the LSM context menu
+			for idx=startIndex, numItems, 1  do
+				local lsmEntry = ZO_MenuData[idx]
+
+				if lsmEntry ~= nil and lsmEntry.name ~= nil then
+					if lib.debugLCM then d("~~~~ Add item of ZO_Menu["..tos(idx).."]: " ..tos(lsmEntry.name)) end
+
+					--Transfer the menu entry now to LibScrollableMenu, instead of ZO_Menu
+					--->pass in lsmEntry as additionlData (last parameter) so m_normalColor etc. will be applied properly too
+					AddCustomScrollableMenuEntry(lsmEntry.name, lsmEntry.callback, lsmEntry.entryType, lsmEntry.entries, lsmEntry)
+					numLSMItemsAddedDuringThisShowMenu = numLSMItemsAddedDuringThisShowMenu + 1
+				else
+					if lib.debugLCM then d("???? ERROR: item of ZO_Menu["..tos(idx).."] is nil, or got no name!") end
+				end
+
+				--Set the last added index now, for next call to ShowMenu()
+				lib.ZO_MenuData_CurrentIndex = idx
+			end
+
+			--No LSM mapped items found? Show normal ZO_Menu now
+			if lib.debugLCM then d(">>> nummber of new added LSM items: " ..tos(numLSMItemsAddedDuringThisShowMenu)) end
+			if numLSMItemsAddedDuringThisShowMenu <= 0 then
+				resetZO_MenuClearVariables()
+				return false -- run original ZO_Menu's ShowMenu()
+			end
+
+			--Set the variable to call ClearMenu() on next reset of the LSM contextmenu (if LSM context menu closes e.g.)
+			lib.callZO_MenuClearMenuOnClearCustomScrollableMenu = true
+
+			--Hide original ZO_Menu (and LibCustomMenu added entries) now -> Do this here AFTER preparing LSM entries,
+			-- else the ZO_Menu.items and sub controls will be emptied already (nil)!
+			-->Important: Do NOT clear the ZO_Menu here!  Keep all entries in ZO_Menu.items. Entries with the same index
+			-->are skipped due to the usage of the index offset lib.ZO_MenuData_CurrentIndex!
+			--> So only visually "hide" the ZO_Menu here but do not call ClearMenu() as this would empty the ZO_Menu.items early!
+			customClearMenu()
+
+
+			--Show the LSM context menu now with the mapped and added ZO_Menu entries, in LSM format.
+			-->ShowCustomScrollableMenu will show all previously added entries plus the new ones
+			showLSMReplacmentContextMenuForZO_MenuNow(owner, ownerName)
+
+			--Hide the ZO_Menu TLC now -> Delayed to next frame (to hide that small [ ] menu TLC near the right clicked mouse position)
+			--> TODO: Moved to customClearMenu() function above. Test if that works
+			--[[
+			zo_callLater(function()
+				ZOMenus:SetHidden(true)
+			end, 1)
+			]]
+
+			--Suppress original ZO_Menu building and "Show" LSM entries now (se above via ShowCustomScrollableMenu( ... ) )
 			return true
-		end
+		end)
+		if lib.debugLCM then d(">>> PreHooked ShowMenu") end
+
+		ZO_Menu_showMenuHooked = true
+	end
+end
+
+
+
+--------------------------------------------------------------------------------------------------------------------
+-- API functions for ZO_Menu hooks of LSM
+--------------------------------------------------------------------------------------------------------------------
+
+--Similar to LibCustomMenu: Register a hook for your addon to use LibScrollableMenu for the context menus
+-->If ANY CustomScrollableContextMenu was registered with LibScrollableMenu:
+-->LibCustomMenu and vanilla ZO_Menu context menus will be suppressed then, mapped into LSM entries and
+-->LSM context menu will be shown instead
+-->Else: Normal ZO_Menu and LibCustomMenu context menus will be used
+function lib.RegisterZO_MenuContextMenuReplacement(addonName)
+	assert(addonName ~= nil and registeredCustomScrollableContextMenus[addonName] == nil, sfor('['..MAJOR..'.RegisterZO_MenuContextMenuReplacement] \'addonName\' missing or already registered: %q', tos(addonName)))
+	registeredCustomScrollableContextMenus[addonName] = true
+	clearZO_MenuAndLSM()
+	--Check if the ZO_Menu hooks need to be applied
+	addZO_Menu_ShowMenuHook()
+end
+local registerZO_MenuContextMenuReplacement = lib.RegisterZO_MenuContextMenuReplacement
+
+
+--Unregister a before registered custom scrollable context menu again
+--Returns true if addon was unregistered, false if addon was not unregistered
+function lib.UnregisterZO_MenuContextMenuReplacement(addonName)
+	if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then
+		resetZO_MenuClearVariables()
+		return
+	end
+	assert(addonName ~= nil, sfor('['..MAJOR..'.UnregisterZO_MenuContextMenuReplacement] \'addonName\' missing: %q', tos(addonName)))
+	if registeredCustomScrollableContextMenus[addonName] ~= nil then
+		registeredCustomScrollableContextMenus[addonName] = nil
+		clearZO_MenuAndLSM()
+		return true
+	end
+	return false
+end
+local unregisterZO_MenuContextMenuReplacement = lib.UnregisterZO_MenuContextMenuReplacement
+
+--Did an addon with name "<addonName>" register a custom scrollable menu as replacement for ZO_Menu?
+function lib.IsZO_MenuContextMenuReplacementRegistered(addonName)
+	if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then
+		resetZO_MenuClearVariables()
 		return false
 	end
-	local unregisterZO_MenuContextMenuReplacement = lib.UnregisterZO_MenuContextMenuReplacement
+	assert(addonName ~= nil, sfor('['..MAJOR..'.IsZO_MenuContextMenuReplacementRegistered] \'addonName\' missing: %q', tos(addonName)))
+	return registeredCustomScrollableContextMenus[addonName] ~= nil
+end
+--local isZO_MenuContextMenuReplacementRegistered = lib.IsZO_MenuContextMenuReplacementRegistered
 
-	--Did an addon with name "<addonName>" register a custom scrollable menu as replacement for ZO_Menu?
-	function lib.IsZO_MenuContextMenuReplacementRegistered(addonName)
-		if not isAnyCustomScrollableZO_MenuContextMenuRegistered() then
-			resetZO_MenuClearVariables()
-			return false
+
+
+--------------------------------------------------------------------------------------------------------------------
+-- API functions for ZO_Menu hooks - Blacklisted controls
+--------------------------------------------------------------------------------------------------------------------
+
+--Add a control to a blacklist that should not be replacing ZO_Menu context menus with LibScrollableMenu context menu.
+-->For these added controls on the blacklist the LSM context menu will not be shown instead of ZO_Menu, but ZO_Menu
+-->will be used.
+-->The controlName must be the name of the control where the context menu opens on, the parent control of that control or
+-->the openingWindow control of that control!
+function lib.AddControlToZO_MenuContextMenuReplacementBlacklist(controlName)
+	local controlNameType = type(controlName)
+	assert(controlNameType == "string" and blacklistedControlsForZO_MenuReplacement[controlName] == nil, sfor('['..MAJOR..'.AddControlToZO_MenuContextMenuReplacementBlacklist] \'controlName\' missing, wrong type %q, or already added. Name: %q', tos(controlNameType), tos(controlName)))
+	blacklistedControlsForZO_MenuReplacement[controlName] = true
+end
+
+--Remove a control from the blacklist that should not be replacing ZO_Menu context menus with LibScrollableMenu context menu.
+-->For these removed controls the LSM context menu will be shown, instead of ZO_Menu
+function lib.RemoveControlFromZO_MenuContextMenuReplacementBlacklist(controlName)
+	local controlNameType = type(controlName)
+	assert(controlNameType == "string" and blacklistedControlsForZO_MenuReplacement[controlName] ~= nil, sfor('['..MAJOR..'.RemoveControlFromZO_MenuContextMenuReplacementBlacklist] \'controlName\' missing, wrong type %q, or was not added yet. Name: %q', tos(controlNameType), tos(controlName)))
+	blacklistedControlsForZO_MenuReplacement[controlName] = nil
+end
+
+--Check if the controlName is on the blacklist (to prevent LSM usage for ZO_Menu)
+function lib.IsControlOnZO_MenuContextMenuReplacementBlacklist(controlName)
+	local controlNameType = type(controlName)
+	assert(controlNameType == "string", sfor('['..MAJOR..'.IsControlOnZO_MenuContextMenuReplacementBlacklist] \'controlName\' missing or wrong type %q. Name: %q', tos(controlNameType), tos(controlName)))
+	return blacklistedControlsForZO_MenuReplacement[controlName] ~= nil
+end
+
+
+
+--Add a control to a whitelist/allowed list that should be replacing ZO_Menu context menus with LibScrollableMenu context menu.
+-->For these added controls on the whitelist the LSM context menu will be shown instead of ZO_Menu.
+-->The controlName must be the name of the control where the context menu opens on, the parent control of that control or
+-->the openingWindow control of that control!
+function lib.AddControlToZO_MenuContextMenuReplacementWhitelist(controlName)
+	local controlNameType = type(controlName)
+	assert(controlNameType == "string" and whitelistedControlNamesForZO_MenuReplacement[controlName] == nil, sfor('['..MAJOR..'.AddControlToZO_MenuContextMenuReplacementWhitelist] \'controlName\' missing, wrong type %q, or already added. Name: %q', tos(controlNameType), tos(controlName)))
+	whitelistedControlNamesForZO_MenuReplacement[controlName] = true
+end
+
+--Remove a control from the whitelist/allowed list that should be replacing ZO_Menu context menus with LibScrollableMenu context menu.
+-->For these removed controls the ZO_Menu context menu will be shown, instead of LSM
+function lib.RemoveControlFromZO_MenuContextMenuReplacementWhitelist(controlName)
+	local controlNameType = type(controlName)
+	assert(controlNameType == "string" and whitelistedControlNamesForZO_MenuReplacement[controlName] ~= nil, sfor('['..MAJOR..'.RemoveControlFromZO_MenuContextMenuReplacementWhitelist] \'controlName\' missing, wrong type %q, or was not added yet. Name: %q', tos(controlNameType), tos(controlName)))
+	whitelistedControlNamesForZO_MenuReplacement[controlName] = nil
+end
+
+--Check if the controlName is on the whitelist (to use LSM instead of ZO_Menu)
+function lib.IsControlOnZO_MenuContextMenuReplacementWhitelist(controlName)
+	local controlNameType = type(controlName)
+	assert(controlNameType == "string", sfor('['..MAJOR..'.IsControlOnZO_MenuContextMenuReplacementWhitelist] \'controlName\' missing or wrong type %q. Name: %q', tos(controlNameType), tos(controlName)))
+	return whitelistedControlNamesForZO_MenuReplacement[controlName] ~= nil
+end
+
+
+--------------------------------------------------------------------------------------------------------------------
+-- Load the ZO_Menu & LCM -> LSM hook via a slash command / or SavedVariables (chanegd via LAM settings menu)
+--------------------------------------------------------------------------------------------------------------------
+local function contextMenuZO_MenuReplacement(switchedOn, silent)
+	silent = silent or false
+	local onOffTag = ""
+	local currentStateOfReplacement = false
+	--Coming from LAM settings switch?
+	if switchedOn ~= nil then
+		currentStateOfReplacement = switchedOn
+	else
+		currentStateOfReplacement = (sv ~= nil and sv.ZO_MenuContextMenuReplacement == true and true) or false
+	end
+
+	if currentStateOfReplacement == true then
+		onOffTag = "ON"
+		sv.ZO_MenuContextMenuReplacement = true
+		registerZO_MenuContextMenuReplacement(MAJOR)
+	else
+		onOffTag = "OFF"
+		sv.ZO_MenuContextMenuReplacement = false
+		unregisterZO_MenuContextMenuReplacement(MAJOR)
+	end
+	if not silent then
+		d("["..MAJOR.."]ZO_Menu context menu replacement switched " .. tos(onOffTag))
+	end
+	return currentStateOfReplacement
+end
+lib.ContextMenuZO_MenuReplacement = contextMenuZO_MenuReplacement
+
+
+
+
+
+--------------------------------------------------------------------------------------------------------------------
+--Slash commands - Context menus
+--------------------------------------------------------------------------------------------------------------------
+--Toggle the replacement of ZO_Menu (including LibCustomMenu) at iventory contextmenus on/off and update the LAM settings menu
+SLASH_COMMANDS["/lsmcontextmenu"] = function()
+	contextMenuZO_MenuReplacement(nil, false)
+	--Is the LAM panel shown then update the checkbox
+	--Refresh the whole LAM panel as the checkbox alone would maybe not be enough (to refresh dependencies)
+	if LAM2 ~= nil then
+		--[[
+		if LSM_LAM_CHECKBOX_REPLACE_ZO_MENU_CONTEXTMENUS ~= nil and not LSM_LAM_CHECKBOX_REPLACE_ZO_MENU_CONTEXTMENUS:IsHidden() then
+			LSM_LAM_CHECKBOX_REPLACE_ZO_MENU_CONTEXTMENUS:UpdateValue(currentStateOfReplacement)
 		end
-		assert(addonName ~= nil, sfor('['..MAJOR..'.IsZO_MenuContextMenuReplacementRegistered] \'addonName\' missing: %q', tos(addonName)))
-		return registeredCustomScrollableContextMenus[addonName] ~= nil
-	end
-	local isZO_MenuContextMenuReplacementRegistered = lib.IsZO_MenuContextMenuReplacementRegistered
-
-
-	--------------------------------------------------------------------------------------------------------------------
-	-- API functions for ZO_Menu hooks - Blacklisted controls
-	--------------------------------------------------------------------------------------------------------------------
-
-	--Add a control to a blacklist that should not be replacing ZO_Menu context menus with LibScrollableMenu context menu.
-	-->For these added controls on the blacklist the LSM context menu will not be shown instead of ZO_Menu, but ZO_Menu
-	-->will be used.
-	-->The controlName must be the name of the control where the context menu opens on, the parent control of that control or
-	-->the openingWindow control of that control!
-	function lib.AddControlToZO_MenuContextMenuReplacementBlacklist(controlName)
-		local controlNameType = type(controlName)
-		assert(controlNameType == "string" and blacklistedControlsForZO_MenuReplacement[controlName] == nil, sfor('['..MAJOR..'.AddControlToZO_MenuContextMenuReplacementBlacklist] \'controlName\' missing, wrong type %q, or already added. Name: %q', tos(controlNameType), tos(controlName)))
-		blacklistedControlsForZO_MenuReplacement[controlName] = true
-	end
-
-	--Remove a control from the blacklist that should not be replacing ZO_Menu context menus with LibScrollableMenu context menu.
-	-->For these removed controls the LSM context menu will be shown, instead of ZO_Menu
-	function lib.RemoveControlFromZO_MenuContextMenuReplacementBlacklist(controlName)
-		local controlNameType = type(controlName)
-		assert(controlNameType == "string" and blacklistedControlsForZO_MenuReplacement[controlName] ~= nil, sfor('['..MAJOR..'.RemoveControlFromZO_MenuContextMenuReplacementBlacklist] \'controlName\' missing, wrong type %q, or was not added yet. Name: %q', tos(controlNameType), tos(controlName)))
-		blacklistedControlsForZO_MenuReplacement[controlName] = nil
-	end
-
-	--Check if the controlName is on the blacklist (to prevent LSM usage for ZO_Menu)
-	function lib.IsControlOnZO_MenuContextMenuReplacementBlacklist(controlName)
-		local controlNameType = type(controlName)
-		assert(controlNameType == "string", sfor('['..MAJOR..'.IsControlOnZO_MenuContextMenuReplacementBlacklist] \'controlName\' missing or wrong type %q. Name: %q', tos(controlNameType), tos(controlName)))
-		return blacklistedControlsForZO_MenuReplacement[controlName] ~= nil
-	end
-
-
-
-	--Add a control to a whitelist/allowed list that should be replacing ZO_Menu context menus with LibScrollableMenu context menu.
-	-->For these added controls on the whitelist the LSM context menu will be shown instead of ZO_Menu.
-	-->The controlName must be the name of the control where the context menu opens on, the parent control of that control or
-	-->the openingWindow control of that control!
-	function lib.AddControlToZO_MenuContextMenuReplacementWhitelist(controlName)
-		local controlNameType = type(controlName)
-		assert(controlNameType == "string" and whitelistedControlNamesForZO_MenuReplacement[controlName] == nil, sfor('['..MAJOR..'.AddControlToZO_MenuContextMenuReplacementWhitelist] \'controlName\' missing, wrong type %q, or already added. Name: %q', tos(controlNameType), tos(controlName)))
-		whitelistedControlNamesForZO_MenuReplacement[controlName] = true
-	end
-
-	--Remove a control from the whitelist/allowed list that should be replacing ZO_Menu context menus with LibScrollableMenu context menu.
-	-->For these removed controls the ZO_Menu context menu will be shown, instead of LSM
-	function lib.RemoveControlFromZO_MenuContextMenuReplacementWhitelist(controlName)
-		local controlNameType = type(controlName)
-		assert(controlNameType == "string" and whitelistedControlNamesForZO_MenuReplacement[controlName] ~= nil, sfor('['..MAJOR..'.RemoveControlFromZO_MenuContextMenuReplacementWhitelist] \'controlName\' missing, wrong type %q, or was not added yet. Name: %q', tos(controlNameType), tos(controlName)))
-		whitelistedControlNamesForZO_MenuReplacement[controlName] = nil
-	end
-
-	--Check if the controlName is on the whitelist (to use LSM instead of ZO_Menu)
-	function lib.IsControlOnZO_MenuContextMenuReplacementWhitelist(controlName)
-		local controlNameType = type(controlName)
-		assert(controlNameType == "string", sfor('['..MAJOR..'.IsControlOnZO_MenuContextMenuReplacementWhitelist] \'controlName\' missing or wrong type %q. Name: %q', tos(controlNameType), tos(controlName)))
-		return whitelistedControlNamesForZO_MenuReplacement[controlName] ~= nil
-	end
-
-
-	--------------------------------------------------------------------------------------------------------------------
-	-- Load the ZO_Menu & LCM -> LSM hook via a slash command
-	--------------------------------------------------------------------------------------------------------------------
-	local function contextMenuZO_MenuReplacement()
-		local onOffTag = ""
-		if isZO_MenuContextMenuReplacementRegistered(MAJOR) then
-			unregisterZO_MenuContextMenuReplacement(MAJOR)
-			onOffTag = "OFF"
-		else
-			registerZO_MenuContextMenuReplacement(MAJOR)
-			onOffTag = "ON"
-		end
-		d("["..MAJOR.."]Provides context menus for whitelisted controls: " .. tos(onOffTag))
-	end
-
-	--Toggle the replacement of ZO_Menu (including LibCustomMenu) at iventory contextmenus on/off
-	SLASH_COMMANDS["/lsmcontextmenu"] = function()
-        contextMenuZO_MenuReplacement()
-    end
-
-	SLASH_COMMANDS["/lsmdebugcontextmenu"] = function()
-		lib.debugLCM = not lib.debugLCM
-		d("["..MAJOR.."]Debugging ZO_Menu context menus for whitelisted controls: " .. tos(lib.debugLCM))
-    end
-
-	--Test for ZO_Menu / LibCustomMenu replacement
-	function lib.Test3()
-		if isZO_MenuContextMenuReplacementRegistered(MAJOR) then
-			--Add another inventory context menu entry
-			AddCustomScrollableMenuEntry("Inv. context menu - Test entry 1", function() d("Inv. context test entry 1 clicked") end, LSM_ENTRY_TYPE_NORMAL, nil, nil)
-			ShowCustomScrollableMenu()
+		]]
+		local LAMaddonPanel = lib.LAMsettingsPanel
+		if not LAMaddonPanel:IsHidden() and LAM2.currentAddonPanel == LAMaddonPanel then
+			LAMaddonPanel:RefreshPanel()
 		end
 	end
+end
 
+SLASH_COMMANDS["/lsmdebugcontextmenu"] = function()
+	lib.debugLCM = not lib.debugLCM
+	d("["..MAJOR.."]Debugging ZO_Menu context menus for whitelisted controls: " .. tos(lib.debugLCM))
+end
 
-------------------------------------------------------------------------------------------------------------------------
-end --function lib.LoadZO_MenuHooks()
-------------------------------------------------------------------------------------------------------------------------
-
+--[[
+--Test for ZO_Menu / LibCustomMenu replacement
+function lib.Test3()
+	if isZO_MenuContextMenuReplacementRegistered(MAJOR) then
+		--Add another inventory context menu entry
+		AddCustomScrollableMenuEntry("Inv. context menu - Test entry 1", function() d("Inv. context test entry 1 clicked") end, LSM_ENTRY_TYPE_NORMAL, nil, nil)
+		ShowCustomScrollableMenu()
+	end
+end
+]]

--- a/LibScrollableMenu/LibScrollableMenu-ZO_Menu.lua
+++ b/LibScrollableMenu/LibScrollableMenu-ZO_Menu.lua
@@ -521,8 +521,8 @@ function lib.LoadZO_MenuHooks()
 				lsmEntry.m_highlightColor = highlightColor or comboBoxDefaults.m_highlightColor
 
 				--TODO LSM 2.4 Add Support for those in LSM comboBoxDefaults etc.!
-				lsmEntry.m_itemYPad = 			 itemYPad or comboBoxDefaults.m_itemYPad
-				lsmEntry.m_horizontalAlignment = horizontalAlignment or comboBoxDefaults.m_horizontalAlignment
+				lsmEntry.m_itemYPad = 			 itemYPad or comboBoxDefaults.itemYPad
+				lsmEntry.m_horizontalAlignment = horizontalAlignment or comboBoxDefaults.horizontalAlignment
 
 				lsmEntry.enabled = 			enabled
 			end

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -13,9 +13,6 @@ lib.version = "2.40"
 
 if not lib then return end
 
---Other libarries
-local LAM2 = LibAddonMenu2
-
 
 --------------------------------------------------------------------
 --SavedVariables
@@ -24,7 +21,12 @@ local LAM2 = LibAddonMenu2
 local lsmSVDefaults = {
 	textSearchHistory = {},			--The header'S text search right click entries (10 last used search terms) per comboBox header
 	collapsedHeaderState = {},		--The collapsed state of the header per owner (comboBox, owningWindow or control opening the contextMenu -> Depending on control type e.g. list control with rows, or not)
-	contextMenuVisibleRows = {}, 	--The context menu visible rows and submenu visible rows per owner (owningWindow or control opening the contextMenu)
+	contextMenuSettings = {
+		["ZO_PlayerInventory"] = {
+			visibleRows = 15,
+			visibleRowsSubmenu = 15,
+		}
+	}, 	--The context menu visible rows and submenu visible rows per owner (owningWindow or control opening the contextMenu)
 }
 local svName = "LibScrollableMenu_SavedVars"
 lib.SV = {} --will be init properly at the onAddonLoaded function
@@ -5412,215 +5414,6 @@ end
 -- Init
 ------------------------------------------------------------------------------------------------------------------------
 
-local existingOwnerNamesList
-local function buildExistingOwnerNamesList()
-	local existingOwnerNamesList = {}
-	sv = lib.SV
-	if sv.visibleRowsContextMenu ~= nil then
-		for ownerControlName, _ in pairs(sv.visibleRowsContextMenu) do
-			existingOwnerNamesList[#existingOwnerNamesList + 1] = ownerControlName
-		end
-	end
-	return existingOwnerNamesList
-end
-
-local function updateExistingOwerNamesList(noLAMControlUpdate)
-	noLAMControlUpdate = noLAMControlUpdate or false
-	existingOwnerNamesList = buildExistingOwnerNamesList()
-
-	if not noLAMControlUpdate then
-		if LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME ~= nil then
-			LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME:UpdateChoices(existingOwnerNamesList)
-		end
-	end
-end
-
-local function buildLibraryLAMSettingsMenu()
-	LAM2 = LibAddonMenu2
-	if LAM2 == nil then return end
-
-	--Add the LAM settings menufor the library to e.g. control the default values for visibleRows of all contextMenus, or
-	--change those for contextMenu's ownerNames (e.g. the ZO_PlayerInventory)
-	local panelData = {
-		type = "panel",
-		name = MAJOR,
-		displayName = MAJOR,
-		author = lib.author,
-		version = lib.version,
-		slashCommand = "/lsmsettings",
-		registerForRefresh = true,
-		registerForDefaults = false,
-	}
-    local LSMLAMPanelName = MAJOR .. "_LAMSettings"
-
-	lib.LAMsettingsPanel = LAM2:RegisterAddonPanel(LSMLAMPanelName, panelData)
-	sv = lib.SV
-
-	local contextMenuOwnerControlName, selectedExistingOwnerName, newVisibleRowsForControlName, newVisibleRowsSubmenuForControlName
-	updateExistingOwerNamesList(true)
-
-	local optionsData = {
-		{
-			type = "header",
-			name = MAJOR,
-		},
-		{
-			type = "description",
-			title = "Context menus",
-			text = "Test description here\n\ntest test test\n\n\nbla blubb",
-		},
-        {
-            type = "editbox",
-            name = "Owner control name",
-            tooltip = "Enter here the control name of a context menu owner, e.g. ZO_PlayerInventory",
-            getFunc = function() return contextMenuOwnerControlName end,
-            setFunc = function(newValue)
-				contextMenuOwnerControlName = newValue
-				if contextMenuOwnerControlName ~= "" then
-					if _G[contextMenuOwnerControlName] == nil then
-						d("["..MAJOR.."]ERROR - Control " .. tos(contextMenuOwnerControlName) .." does not globally exist!")
-						contextMenuOwnerControlName = nil
-						selectedExistingOwnerName = nil
-						newVisibleRowsForControlName = nil
-						newVisibleRowsSubmenuForControlName = nil
-					else
-						newVisibleRowsForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRows"]) or comboBoxDefaults.visibleRows
-						newVisibleRowsSubmenuForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRowsSubmenu"]) or comboBoxDefaults.visibleRowsSubmenu
-					end
-				else
-					contextMenuOwnerControlName = nil
-					selectedExistingOwnerName = nil
-					newVisibleRowsForControlName = nil
-					newVisibleRowsSubmenuForControlName = nil
-				end
-			end,
-            disabled = function() return false end,
-			width = "full",
-			default = "",
-        },
-        {
-            type = "slider",
-            name = "Visible rows #",
-            tooltip = "Enter the number of visible rows at the contextmenu of the owner's controlName",
-            getFunc = function()
-				return newVisibleRowsForControlName or comboBoxDefaults.visibleRows
-			end,
-            setFunc = function(newValue)
-				newVisibleRowsForControlName = newValue
-            end,
-			step = 1,
-			min = 5,
-			max = 30,
-            disabled = function() return contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "" end,
-			width = "half",
-			default = comboBoxDefaults.visibleRows,
-        },
-        {
-            type = "slider",
-            name = "Visible rows #, submenus",
-            tooltip = "Enter the number of visible rows at the contextmenu's submenus of the owner's controlName",
-            getFunc = function()
-				return newVisibleRowsSubmenuForControlName or comboBoxDefaults.visibleRowsSubmenu
-			end,
-            setFunc = function(newValue)
-				newVisibleRowsSubmenuForControlName = newValue
-            end,
-			step = 1,
-			min = 5,
-			max = 30,
-            disabled = function() return contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "" end,
-			width = "half",
-			default = comboBoxDefaults.visibleRowsSubmenu,
-        },
-        {
-            type = "button",
-            name = "Apply visibleRows",
-            tooltip = "Change the visible rows and visible rows of the submenu for the entered context menu owner's controlName.",
-            func = function()
-				if contextMenuOwnerControlName ~= nil and (newVisibleRowsForControlName ~= nil or newVisibleRowsSubmenuForControlName ~= nil) then
-					--Add the savedvariables update of sv.visibleRowsContextMenu[contextMenuOwnerControlName]
-					if newVisibleRowsForControlName ~= nil then
-						sv.visibleRowsContextMenu = sv.visibleRowsContextMenu or {}
-						sv.visibleRowsContextMenu[contextMenuOwnerControlName] = sv.visibleRowsContextMenu[contextMenuOwnerControlName] or {}
-						sv.visibleRowsContextMenu[contextMenuOwnerControlName].visibleRows = newVisibleRowsForControlName
-					end
-					if newVisibleRowsSubmenuForControlName ~= nil then
-						sv.visibleRowsContextMenu = sv.visibleRowsContextMenu or {}
-						sv.visibleRowsContextMenu[contextMenuOwnerControlName] = sv.visibleRowsContextMenu[contextMenuOwnerControlName] or {}
-						sv.visibleRowsContextMenu[contextMenuOwnerControlName].visibleRowsSubmenu = newVisibleRowsSubmenuForControlName
-					end
-					contextMenuOwnerControlName = nil
-					selectedExistingOwnerName = nil
-					newVisibleRowsForControlName = nil
-					newVisibleRowsSubmenuForControlName = nil
-
-					updateExistingOwerNamesList(false)
-				end
-			end,
-            disabled = function() return (contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "") or (newVisibleRowsForControlName == nil and newVisibleRowsSubmenuForControlName == nil) end,
-        },
-        {
-            type = "dropdown",
-			name = "Already added owner names",
-			tooltip = "Choose an already added owner's controlName to change the values, or to delete it.",
-			choices = existingOwnerNamesList,
-			getFunc = function() return selectedExistingOwnerName end,
-			setFunc = function(selectedOwnerName)
-				selectedExistingOwnerName = selectedOwnerName
-				contextMenuOwnerControlName = selectedOwnerName
-				newVisibleRowsForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[selectedOwnerName] and sv.visibleRowsContextMenu[selectedOwnerName]["visibleRows"]) or comboBoxDefaults.visibleRows
-				newVisibleRowsSubmenuForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[selectedOwnerName] and sv.visibleRowsContextMenu[selectedOwnerName]["visibleRowsSubmenu"]) or comboBoxDefaults.visibleRowsSubmenu
-				--[[
-				for ownerName, _ in pairs(sv.visibleRowsContextMenu) do
-					if ownerName == selectedOwnerName then
-						selectedExistingOwnerName = selectedOwnerName
-						contextMenuOwnerControlName = selectedOwnerName
-                        break
-					end
-				end
-				]]
-			end,
-            scrollable = true,
-			width = "half",
-			default = function() return nil end,
-			reference = "LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME"
-        },
-        {
-            type = "button",
-            name = "Delete control name",
-            tooltip = "Delete the selected owner's controlName from the saved controls list",
-            func = function()
-				if selectedExistingOwnerName ~= nil then
-					if sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[selectedExistingOwnerName] ~= nil then
-						sv.visibleRowsContextMenu[selectedExistingOwnerName] = nil
-					end
-					selectedExistingOwnerName = nil
-					contextMenuOwnerControlName = nil
-					newVisibleRowsForControlName = nil
-					newVisibleRowsSubmenuForControlName = nil
-
-					updateExistingOwerNamesList(false)
-				end
-			end,
-            disabled = function() return selectedExistingOwnerName == nil or selectedExistingOwnerName == "" or contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "" or contextMenuOwnerControlName ~= selectedExistingOwnerName end,
-        },
-
-	}
-	LAM2:RegisterOptionControls(LSMLAMPanelName, optionsData)
-
-    local function openedPanel(panel)
-        if panel ~= lib.LAMsettingsPanel then return end
-
-		selectedExistingOwnerName = nil
-		contextMenuOwnerControlName = nil
-		newVisibleRowsForControlName = nil
-		newVisibleRowsSubmenuForControlName = nil
-
-		updateExistingOwerNamesList(false)
-    end
-    CALLBACK_MANAGER:RegisterCallback("LAM-PanelOpened", openedPanel)
-end
-
 --Load of the addon/library starts
 local function onAddonLoaded(event, name)
 	if name:find("^ZO_") then return end
@@ -5696,7 +5489,7 @@ local function onAddonLoaded(event, name)
 
 
 	--Build the library settings menu if LAM is available
-	buildLibraryLAMSettingsMenu()
+	lib.BuildLAMSettingsMenu()
 end
 EM:UnregisterForEvent(MAJOR, EVENT_ADD_ON_LOADED)
 EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -5412,6 +5412,7 @@ end
 -- Init
 ------------------------------------------------------------------------------------------------------------------------
 
+local existingOwnerNamesList
 local function buildExistingOwnerNamesList()
 	local existingOwnerNamesList = {}
 	sv = lib.SV
@@ -5421,6 +5422,17 @@ local function buildExistingOwnerNamesList()
 		end
 	end
 	return existingOwnerNamesList
+end
+
+local function updateExistingOwerNamesList(noLAMControlUpdate)
+	noLAMControlUpdate = noLAMControlUpdate or false
+	existingOwnerNamesList = buildExistingOwnerNamesList()
+
+	if not noLAMControlUpdate then
+		if LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME ~= nil then
+			LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME:UpdateChoices(existingOwnerNamesList)
+		end
+	end
 end
 
 local function buildLibraryLAMSettingsMenu()
@@ -5445,7 +5457,7 @@ local function buildLibraryLAMSettingsMenu()
 	sv = lib.SV
 
 	local contextMenuOwnerControlName, selectedExistingOwnerName, newVisibleRowsForControlName, newVisibleRowsSubmenuForControlName
-	local existingOwnerNamesList = buildExistingOwnerNamesList()
+	updateExistingOwerNamesList(true)
 
 	local optionsData = {
 		{
@@ -5470,6 +5482,9 @@ local function buildLibraryLAMSettingsMenu()
 					selectedExistingOwnerName = nil
 					newVisibleRowsForControlName = nil
 					newVisibleRowsSubmenuForControlName = nil
+				else
+					newVisibleRowsForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRows"]) or comboBoxDefaults.visibleRows
+					newVisibleRowsSubmenuForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRowsSubmenu"]) or comboBoxDefaults.visibleRowsSubmenu
 				end
 			end,
             disabled = function() return false end,
@@ -5481,7 +5496,7 @@ local function buildLibraryLAMSettingsMenu()
             name = "Visible rows #",
             tooltip = "Enter the number of visible rows at the contextmenu of the owner's controlName",
             getFunc = function()
-				return newVisibleRowsForControlName
+				return newVisibleRowsForControlName or comboBoxDefaults.visibleRows
 			end,
             setFunc = function(newValue)
 				newVisibleRowsForControlName = newValue
@@ -5498,7 +5513,7 @@ local function buildLibraryLAMSettingsMenu()
             name = "Visible rows #, submenus",
             tooltip = "Enter the number of visible rows at the contextmenu's submenus of the owner's controlName",
             getFunc = function()
-				return newVisibleRowsSubmenuForControlName
+				return newVisibleRowsSubmenuForControlName or comboBoxDefaults.visibleRowsSubmenu
 			end,
             setFunc = function(newValue)
 				newVisibleRowsSubmenuForControlName = newValue
@@ -5531,6 +5546,8 @@ local function buildLibraryLAMSettingsMenu()
 					selectedExistingOwnerName = nil
 					newVisibleRowsForControlName = nil
 					newVisibleRowsSubmenuForControlName = nil
+
+					updateExistingOwerNamesList(false)
 				end
 			end,
             disabled = function() return (contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "") or (newVisibleRowsForControlName == nil and newVisibleRowsSubmenuForControlName == nil) end,
@@ -5575,10 +5592,7 @@ local function buildLibraryLAMSettingsMenu()
 					newVisibleRowsForControlName = nil
 					newVisibleRowsSubmenuForControlName = nil
 
-					existingOwnerNamesList = buildExistingOwnerNamesList()
-					if LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME ~= nil then
-						LSM_LAM_DROPDOWN_SELECTED_EXISTING_OWNER_NAME:UpdateChoices(existingOwnerNamesList)
-					end
+					updateExistingOwerNamesList(false)
 				end
 			end,
             disabled = function() return selectedExistingOwnerName == nil or selectedExistingOwnerName == "" or contextMenuOwnerControlName == nil or contextMenuOwnerControlName == "" or contextMenuOwnerControlName ~= selectedExistingOwnerName end,
@@ -5587,12 +5601,17 @@ local function buildLibraryLAMSettingsMenu()
 	}
 	LAM2:RegisterOptionControls(LSMLAMPanelName, optionsData)
 
-	--[[
     local function openedPanel(panel)
         if panel ~= lib.LAMsettingsPanel then return end
+
+		selectedExistingOwnerName = nil
+		contextMenuOwnerControlName = nil
+		newVisibleRowsForControlName = nil
+		newVisibleRowsSubmenuForControlName = nil
+
+		updateExistingOwerNamesList(false)
     end
     CALLBACK_MANAGER:RegisterCallback("LAM-PanelOpened", openedPanel)
-    ]]
 end
 
 --Load of the addon/library starts

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -302,6 +302,7 @@ local comboBoxDefaults = {
 	m_maxNumSelections = 			nil,
 	m_height = 						DEFAULT_HEIGHT,
 	horizontalAlignment = 			TEXT_ALIGN_LEFT,
+	itemYPad = 						0, --LibScrollableMenu support
 
 	--LibScrollableMenu internal (e.g. .options)
 	disableFadeGradient = 			false,
@@ -311,6 +312,7 @@ local comboBoxDefaults = {
 	baseEntryHeight = 				ZO_COMBO_BOX_ENTRY_TEMPLATE_HEIGHT,
 	headerCollapsed = 				false,
 }
+lib.comboBoxDefaults = comboBoxDefaults
 
 --The default values for dropdownHelper options -> used for non-passed in options at LSM API functions
 local defaultComboBoxOptions  = {

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -5476,15 +5476,22 @@ local function buildLibraryLAMSettingsMenu()
             getFunc = function() return contextMenuOwnerControlName end,
             setFunc = function(newValue)
 				contextMenuOwnerControlName = newValue
-				if _G[contextMenuOwnerControlName] == nil then
-					d("["..MAJOR.."]ERROR - Control " .. tos(contextMenuOwnerControlName) .." does not globally exist!")
+				if contextMenuOwnerControlName ~= "" then
+					if _G[contextMenuOwnerControlName] == nil then
+						d("["..MAJOR.."]ERROR - Control " .. tos(contextMenuOwnerControlName) .." does not globally exist!")
+						contextMenuOwnerControlName = nil
+						selectedExistingOwnerName = nil
+						newVisibleRowsForControlName = nil
+						newVisibleRowsSubmenuForControlName = nil
+					else
+						newVisibleRowsForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRows"]) or comboBoxDefaults.visibleRows
+						newVisibleRowsSubmenuForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRowsSubmenu"]) or comboBoxDefaults.visibleRowsSubmenu
+					end
+				else
 					contextMenuOwnerControlName = nil
 					selectedExistingOwnerName = nil
 					newVisibleRowsForControlName = nil
 					newVisibleRowsSubmenuForControlName = nil
-				else
-					newVisibleRowsForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRows"]) or comboBoxDefaults.visibleRows
-					newVisibleRowsSubmenuForControlName = (sv.visibleRowsContextMenu and sv.visibleRowsContextMenu[contextMenuOwnerControlName] and sv.visibleRowsContextMenu[contextMenuOwnerControlName]["visibleRowsSubmenu"]) or comboBoxDefaults.visibleRowsSubmenu
 				end
 			end,
             disabled = function() return false end,

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -5436,6 +5436,8 @@ local function onAddonLoaded(event, name)
 	end)
 
 	--ZO_Menu - ShowMenu hook: Hide LSM if a ZO_Menu menu opens
+	--[[
+	--Disabled here as this needs to be moved to file LibScrollableMenu-ZO_Menu.lua, PreHook of ShowMenu!
 	ZO_PreHook("ShowMenu", function(owner, initialRefCount, menuType)
 		dLog(LSM_LOGTYPE_VERBOSE, "ZO_Menu -> ShowMenu. Items#: " ..tos(#ZO_Menu.items) .. ", menuType: " ..tos(menuType))
 		--Do not close on other menu types (only default menu type supported)
@@ -5446,13 +5448,14 @@ local function onAddonLoaded(event, name)
 			return false
 		end
 		--Should the ZO_Menu not close any opened LSM? e.g. to show the textSearchHistory at the LSM text filter search box
-		if lib.preventLSMClosingZO_Menu then
+		if lib.preventLSMClosingZO_Menu == true then
 			lib.preventLSMClosingZO_Menu = nil
 			return
 		end
 		hideCurrentlyOpenedLSMAndContextMenu()
 		return false
 	end)
+	]]
 
 	--------------------------------------------------------------------------------------------------------------------
 	--Slash commands

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -13,6 +13,9 @@ lib.version = "2.40"
 
 if not lib then return end
 
+--Other libraries
+local LAM2 = LibAddonMenu2
+local LCM = LibCustomMenu
 
 --------------------------------------------------------------------
 --SavedVariables
@@ -21,6 +24,7 @@ if not lib then return end
 local lsmSVDefaults = {
 	textSearchHistory = {},			--The header'S text search right click entries (10 last used search terms) per comboBox header
 	collapsedHeaderState = {},		--The collapsed state of the header per owner (comboBox, owningWindow or control opening the contextMenu -> Depending on control type e.g. list control with rows, or not)
+	ZO_MenuContextMenuReplacement = false, --Replace all ZO_Menu and LibCustomMenu contextMenus with LSM?
 	contextMenuSettings = {
 		["ZO_PlayerInventory"] = {
 			visibleRows = 15,
@@ -5421,6 +5425,12 @@ local function onAddonLoaded(event, name)
 	loadLogger()
 	dLog(LSM_LOGTYPE_DEBUG, "~~~~~ onAddonLoaded ~~~~~")
 
+	--Other libraries
+	LAM2 = LAM2 or LibAddonMenu2
+	lib.LAM2 = LAM2
+	LCM = LCM or LibCustomMenu
+	lib.LCM = LCM
+
 	--SavedVariables
 	lib.SV = ZO_SavedVars:NewAccountWide(svName, 1, "LSM", lsmSVDefaults)
 	sv = lib.SV
@@ -5466,6 +5476,14 @@ local function onAddonLoaded(event, name)
 	end)
 	]]
 
+	--Build the library settings menu if LAM is available
+	lib.BuildLAMSettingsMenu()
+
+	--Enable the ZO_Menu contextmenu hooks if they were switche don
+	lib.ContextMenuZO_MenuReplacement((sv ~= nil and sv.ZO_MenuContextMenuReplacement == true and true) or false, true) --silent, no chat output
+
+
+
 	--------------------------------------------------------------------------------------------------------------------
 	--Slash commands
 	--------------------------------------------------------------------------------------------------------------------
@@ -5483,13 +5501,6 @@ local function onAddonLoaded(event, name)
 			dLog(LSM_LOGTYPE_DEBUG, "Verbose debugging turned %s / Debugging: %s", tos(lib.doVerboseDebug and "ON" or "OFF"), tos(lib.doDebug and "ON" or "OFF"))
 		end
 	end
-
-	--Load the hooks for ZO_Menu and allow replacement of ZO_Menu items with LSM entries
-	lib.LoadZO_MenuHooks()
-
-
-	--Build the library settings menu if LAM is available
-	lib.BuildLAMSettingsMenu()
 end
 EM:UnregisterForEvent(MAJOR, EVENT_ADD_ON_LOADED)
 EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -10,7 +10,7 @@
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101043 101044
-## OptionalDependsOn: LibDebugLogger>=263 LibCustomMenu>=722
+## OptionalDependsOn: LibAddonMenu-2.0>=37 LibDebugLogger>=263 LibCustomMenu>=722
 ## SavedVariables: LibScrollableMenu_SavedVars
 
 lang/en.lua

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -18,6 +18,7 @@ lang/$(language).lua
 
 ##Library lua code files
 LibScrollableMenu.lua
+LibScrollableMenu-LAMSettings.lua
 
 ##Library XML templates files
 LibScrollableMenu.xml

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,5 +1,9 @@
--v- ---------------LSM v2.4 - 2024-xx-xx---------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.4 - 2024-10-22---------------------------------------------------------------------------- -v-
 -Added support for ZO_Menu and LibCustomMenu at inventory context menus
+-Added LAM settings menu for the ZO_Menu -> LSM context menu replacements, including a possibilty to define the (submenu)rows shown at controlNames (e.g. ZO_PlayerInventory)
+-Added return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
+-Renamed API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
+
 
 
 -v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-


### PR DESCRIPTION
LSM BETA v2.4
-Added support for ZO_Menu and LibCustomMenu at inventory context menus
-Added LAM settings menu for the ZO_Menu -> LSM context menu replacements, including a possibilty to define the (submenu)rows shown at controlNames (e.g. ZO_PlayerInventory)
-Added return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
-Renamed API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
