### PR TITLE
LSM v2.33

### DIFF
--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -97,6 +97,9 @@ local function test()
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
 
+			headerFont = "ZoFontHeader3",
+			headerColor = CUSTOM_DISABLED_TEXT_COLOR,
+
 			--useDefaultHighlightForSubmenuWithCallback = true,
 
 			--sortEntries=function() return false end,

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -1,6 +1,8 @@
 local lib = LibScrollableMenu
 local MAJOR = lib.name
 
+local debugPrefix = lib.Debug.prefix
+
 ------------------------------------------------------------------------------------------------------------------------
 -- For testing - Combobox with all kind of entry types (test offsets, etc.)
 ------------------------------------------------------------------------------------------------------------------------
@@ -171,7 +173,7 @@ local function test()
 		--Try to change the options of the scrollhelper as it gets created
 		--[[
 		lib:RegisterCallback('OnDropdownMenuAdded', function(comboBox, optionsPassedIn)
---d("[LSM]TEST - Callback fired: OnDropdownMenuAdded - current visibleRows: " ..tostring(optionsPassedIn.visibleRowsDropdown))
+--d(debugPrefix .. "TEST - Callback fired: OnDropdownMenuAdded - current visibleRows: " ..tostring(optionsPassedIn.visibleRowsDropdown))
 			optionsPassedIn.visibleRowsDropdown = 5 -- Overwrite the visible rows at the dropdown
 --d("<visibleRows after: " ..tostring(optionsPassedIn.visibleRowsDropdown))
 		end)
@@ -293,7 +295,7 @@ local function test()
 
 						local function myAddonCallbackFuncSubmenu(p_comboBox, p_item, entriesFound) --... will be filled with customParams
 							--Loop at entriesFound, get it's .data.dataSource etc and check SavedVAriables etc.
-d("[LSM]Context menu submenu - Custom menu Normal entry 1->RunCustomScrollableMenuItemsCallback: WAS EXECUTED!")
+d(debugPrefix .. "Context menu submenu - Custom menu Normal entry 1->RunCustomScrollableMenuItemsCallback: WAS EXECUTED!")
 							for k, v in ipairs(entriesFound) do
 								local name = v.label or v.name
 								d(">name of entry: " .. tostring(name).. ", checked: " .. tostring(v.checked))
@@ -330,7 +332,7 @@ d("[LSM]Context menu submenu - Custom menu Normal entry 1->RunCustomScrollableMe
 
 						local function myAddonCallbackFuncSubmenu(p_comboBox, p_item, entriesFound) --... will be filled with customParams
 							--Loop at entriesFound, get it's .data.dataSource etc and check SavedVAriables etc.
-d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollableMenuItemsCallback: WAS EXECUTED!")
+d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollableMenuItemsCallback: WAS EXECUTED!")
 							for k, v in ipairs(entriesFound) do
 								local name = v.label or v.name
 								d(">[Same menu]name of entry: " .. tostring(name).. ", checked: " .. tostring(v.checked))
@@ -701,7 +703,7 @@ d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollab
 
 						local function myAddonCallbackFunc(p_comboBox, p_item, entriesFound, ...) --... will be filled with customParams
 							--Loop at entriesFound, get it's .data.dataSource etc and check SavedVAriables etc.
-							d("[LSM]Context menu - Normal entry 1->RunCustomScrollableMenuItemsCallback: WAS EXECUTED!")
+							d(debugPrefix .. "Context menu - Normal entry 1->RunCustomScrollableMenuItemsCallback: WAS EXECUTED!")
 							for k, v in ipairs(entriesFound) do
 								local name = v.label or v.name
 								d(">name of checkbox: " .. tostring(name).. ", checked: " .. tostring(v.checked))
@@ -1121,7 +1123,7 @@ d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollab
 		--DOES NOT WORK
 		ZO_PlayerInventoryTabsActive:SetMouseEnabled(true)
 		ZO_PlayerInventoryTabsActive:SetHandler("OnMouseUp", function(ctrl, button, upInside)
-			d("[LSM]ZO_PlayerInventoryTabsActive - OnMouseUp")
+			d(debugPrefix .. "ZO_PlayerInventoryTabsActive - OnMouseUp")
 			if upInside and button == MOUSE_BUTTON_INDEX_RIGHT then
 				ClearCustomScrollableMenu()
 
@@ -1163,7 +1165,7 @@ d("[LSM]Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCustomScrollab
 
 		--DOES WORK
 		ZO_PreHookHandler(ZO_PlayerInventoryMenuBarButton1, "OnMouseUp", function(ctrl, button, upInside)
-			d("[LSM]ZO_PlayerInventoryMenuBarButton1 - OnMouseUp")
+			d(debugPrefix .. "ZO_PlayerInventoryMenuBarButton1 - OnMouseUp")
 			if upInside and button == MOUSE_BUTTON_INDEX_RIGHT then
 				ClearCustomScrollableMenu()
 
@@ -1215,7 +1217,7 @@ local function test2()
 		else
 			optionsVisibleRowsCurrent = 10
 		end
-d("[LSM]Test2 - Updating options- toggling visibleRows to: " ..tostring(optionsVisibleRowsCurrent) .. ", disableFadeGradient to: " ..tostring(optionsDisableFadeGradient))
+d(debugPrefix .. "Test2 - Updating options- toggling visibleRows to: " ..tostring(optionsVisibleRowsCurrent) .. ", disableFadeGradient to: " ..tostring(optionsDisableFadeGradient))
 
 		if optionsDisableFadeGradient then
 			optionsDisableFadeGradient = false

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -99,8 +99,9 @@ local function test()
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
 
-			headerFont = "ZoFontHeader3",
-			headerColor = CUSTOM_DISABLED_TEXT_COLOR,
+			--Big yellow headers!
+			--headerFont = "ZoFontHeader3",
+			--headerColor = CUSTOM_DISABLED_TEXT_COLOR,
 
 			--useDefaultHighlightForSubmenuWithCallback = true,
 
@@ -593,7 +594,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 				entryType		= LSM_ENTRY_TYPE_RADIOBUTTON,
 				label			= "Radiobutton group 1-1",
 				name            = "Radiobutton group 1-1",
-				tooltip         = "Button button button...",
+				tooltip         = "Radiobutton tooltip 1",
 				checked 		= true,
 				callback 		= function(comboBox, itemName, item, checked)
 					d("I clicked Radiobutton group 1-1 with the name: " .. tostring(itemName))
@@ -605,7 +606,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 				entryType		= LSM_ENTRY_TYPE_RADIOBUTTON,
 				label			= "Radiobutton group 1-2",
 				name            = "Radiobutton group 1-2",
-				tooltip         = "Button button button...",
+				tooltip         = "Radiobutton tooltip 2",
 				checked 		= false,
 				callback 		= function(comboBox, itemName, item, checked)
 					d("I clicked Radiobutton group 1-2 with the name: " .. tostring(itemName))
@@ -617,7 +618,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 				entryType		= LSM_ENTRY_TYPE_RADIOBUTTON,
 				label			= "Radiobutton group 2-3",
 				name            = "Radiobutton group 2-3",
-				tooltip         = "Button button button...",
+				tooltip         = "Radiobutton tooltip 3",
 				checked 		= true,
 				callback 		= function(comboBox, itemName, item, checked)
 					d("I clicked Radiobutton group 2-3 with the name: " .. tostring(itemName))
@@ -628,7 +629,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 				entryType		= LSM_ENTRY_TYPE_RADIOBUTTON,
 				label			= "Radiobutton group 2-4",
 				name            = "Radiobutton group 2-4",
-				tooltip         = "Button button button...",
+				tooltip         = "Radiobutton tooltip 4",
 				checked 		= false,
 				callback 		= function(comboBox, itemName, item, checked)
 					d("I clicked Radiobutton group 2-4 with the name: " .. tostring(itemName))

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -288,7 +288,7 @@ d("[LSM]Context menu submenu - Custom menu Normal entry 1->RunCustomScrollableMe
 				end,
 				--tooltip         = "Submenu Entry Test 1",
 				--icon 			= nil,
-				m_highlightTemplate = "LibScrollableMenu_Highlight_Red",
+				m_highlightTemplate = lib.LSM_ROW_HIGHLIGHT_RED --"LibScrollableMenu_Highlight_Red",
 			},
 			{
 

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -138,9 +138,31 @@ local function test()
 						comboBox:SetupEntryLabel(control, data, list)
 					end,
 				}
-			}
-
+			},
 			]]
+
+			XMLRowHighlightTemplates = {
+				[lib.LSM_ENTRY_TYPE_NORMAL] = {
+					template = lib.LSM_ROW_HIGHLIGHT_DEFAULT, --"ZO_SelectionHighlight",
+					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
+				},
+				[lib.LSM_ENTRY_TYPE_SUBMENU] = {
+					template = lib.LSM_ROW_HIGHLIGHT_DEFAULT, --"ZO_SelectionHighlight", --Will be replaced with green if submenu entry got callback
+					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
+				},
+				[lib.LSM_ENTRY_TYPE_CHECKBOX] = {
+					template = lib.LSM_ROW_HIGHLIGHT_BLUE, --"LibScrollableMenu_Highlight_Blue",
+					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
+				},
+				[lib.LSM_ENTRY_TYPE_BUTTON] = {
+					template = lib.LSM_ROW_HIGHLIGHT_RED, --"LibScrollableMenu_Highlight_Red",
+					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
+				},
+				[lib.LSM_ENTRY_TYPE_RADIOBUTTON] = {
+					template = lib.LSM_ROW_HIGHLIGHT_WHITE, --"LibScrollableMenu_Highlight_White",
+					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
+				},
+			},
 		}
 
 		--Try to change the options of the scrollhelper as it gets created

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -139,7 +139,6 @@ local function test()
 					end,
 				}
 			},
-			]]
 
 			XMLRowHighlightTemplates = {
 				[lib.LSM_ENTRY_TYPE_NORMAL] = {
@@ -159,10 +158,11 @@ local function test()
 					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
 				},
 				[lib.LSM_ENTRY_TYPE_RADIOBUTTON] = {
-					template = lib.LSM_ROW_HIGHLIGHT_WHITE, --"LibScrollableMenu_Highlight_White",
+					template = lib.LSM_ROW_HIGHLIGHT_OPAQUE, --"LibScrollableMenu_Highlight_White",
 					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
 				},
 			},
+			]]
 		}
 
 		--Try to change the options of the scrollhelper as it gets created

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1591,11 +1591,6 @@ local function getComboBox(control, owningMenu)
 	end
 end
 
-local function fireOnDropownMenuAddedCallback(selfVar, options)
-d("[LSM]FireCallbacks - OnDropdownMenuAdded - current visibleRows: " ..tostring(options.visibleRowsDropdown))
-	lib:FireCallbacks('OnDropdownMenuAdded', selfVar, options)
-	dLog(LSM_LOGTYPE_DEBUG_CALLBACK, "FireCallbacks: OnDropdownMenuAdded - control: %s, options: %s", tos(getControlName(selfVar.m_container)), tos(options))
-end
 
 ------------------------------------------------------------------------------------------------------------------------
 --Local context menu helper functions
@@ -4620,7 +4615,8 @@ function comboBoxClass:UpdateMetatable(parent, comboBoxContainer, options)
 	ApplyTemplateToControl(comboBoxContainer, 'LibScrollableMenu_ComboBox_Behavior')
 
 	--Fire the OnDropdownMenuAdded callback where one can replace options in the options table
-	fireOnDropownMenuAddedCallback(self, options)
+	lib:FireCallbacks('OnDropdownMenuAdded', self, options)
+	dLog(LSM_LOGTYPE_DEBUG_CALLBACK, "FireCallbacks: OnDropdownMenuAdded - control: %s, options: %s", tos(getControlName(self.m_container)), tos(options))
 
 	self:Initialize(parent, comboBoxContainer, options, 1, true)
 end
@@ -4894,6 +4890,8 @@ end
 function contextMenuClass:ShowContextMenu(parentControl)
 	dLog(LSM_LOGTYPE_VERBOSE, "contextMenuClass:ShowContextMenu - parentControl: %s", tos(getControlName(parentControl)))
 
+d("[LSM]contextMenuClass:ShowContextMenu")
+
 	local openingControlOld = self.openingControl
 	self.openingControl = parentControl
 
@@ -4943,8 +4941,9 @@ function contextMenuClass:SetContextMenuOptions(options)
 	end
 	]]
 
-	-- self.optionsData is only a temporary table used check for change and to send to UpdateOptions.
+	-- self.optionsData is only a temporary table used to check for changes and to send to UpdateOptions.
 	self.optionsChanged = self.optionsData ~= options
+d("[LSM]contextMenuClass:SetContextMenuOptions - optionsChanged: " .. tos(self.optionsChanged))
 	self.optionsData = options
 end
 
@@ -5251,20 +5250,23 @@ function SetCustomScrollableMenuOptions(options, comboBoxContainer)
 
 	dLog(LSM_LOGTYPE_DEBUG, "SetCustomScrollableMenuOptions - comboBoxContainer: %s, options: %s", tos(getControlName(comboBoxContainer)), tos(options))
 
+
+df("[LSM]SetCustomScrollableMenuOptions - comboBoxContainer: %s, options: %s", tos(getControlName(comboBoxContainer)), tos(options))
+
 	--Use specified comboBoxContainer's dropdown to update the options to
 	if comboBoxContainer ~= nil then
 		local comboBox = ZO_ComboBox_ObjectFromContainer(comboBoxContainer)
 		if comboBox ~= nil and comboBox.UpdateOptions then
 			comboBox.optionsChanged = options ~= comboBox.options
---d(">SetCustomScrollableMenuOptions - Found UpdateOptions - optionsChanged: " ..tos(comboBox.optionsChanged))
+d(">SetCustomScrollableMenuOptions - Found UpdateOptions - optionsChanged: " ..tos(comboBox.optionsChanged))
 			comboBox:UpdateOptions(options)
 		end
 	else
+d(">SetContextMenuOptions")
 		--Update options to default contextMenu
 		g_contextMenu:SetContextMenuOptions(options)
 	end
 end
-
 local setCustomScrollableMenuOptions = SetCustomScrollableMenuOptions
 
 --Hide the custom scrollable context menu and clear it's entries, clear internal variables, mouse clicks etc.
@@ -5338,12 +5340,13 @@ end
 --Existing context menu entries will be kept (until ClearCustomScrollableMenu will be called)
 function ShowCustomScrollableMenu(controlToAnchorTo, options)
 	dLog(LSM_LOGTYPE_DEBUG, "ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
---df("_-_-_-_-_-_-_-_-_-_ [LSM]ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
+df("_-_-_-_-_-_-_-_-_-_ [LSM]ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
 
 	--Fire the OnDropdownMenuAdded callback where one can replace options in the options table -> Here: For the contextMenu
-	fireOnDropownMenuAddedCallback(g_contextMenu, options)
-
+	lib:FireCallbacks('OnDropdownMenuAdded', g_contextMenu, options)
+	dLog(LSM_LOGTYPE_DEBUG_CALLBACK, "FireCallbacks: ContextMenu - OnDropdownMenuAdded - control: %s, options: %s", tos(getControlName(g_contextMenu.m_container)), tos(options))
 	if options then
+d(">calling SetCustomScrollableMenuOptions")
 		setCustomScrollableMenuOptions(options)
 	end
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -35,6 +35,10 @@ lib.Debug.doDebug = false
 lib.Debug.doVerboseDebug = false
 local libDebug = lib.Debug
 
+local debugPrefix = "[" .. MAJOR .. "]"
+libDebug.prefix = debugPrefix
+
+
 local function initDebugLogging()
 	if not lib.Debug then return false end
 	libDebug = lib.Debug
@@ -196,13 +200,13 @@ local libDivider = lib.DIVIDER
 
 --Make them accessible for the DropdownObject:New options table -> options.XMLRowTemplates
 lib.scrollListRowTypes = {
-	["LSM_ENTRY_TYPE_NORMAL"] =		LSM_ENTRY_TYPE_NORMAL,
-	["LSM_ENTRY_TYPE_DIVIDER"] = 	LSM_ENTRY_TYPE_DIVIDER,
-	["LSM_ENTRY_TYPE_HEADER"] = 	LSM_ENTRY_TYPE_HEADER,
-	["LSM_ENTRY_TYPE_SUBMENU"] = 	LSM_ENTRY_TYPE_SUBMENU,
-	["LSM_ENTRY_TYPE_CHECKBOX"] =	LSM_ENTRY_TYPE_CHECKBOX,
-	["LSM_ENTRY_TYPE_BUTTON"] =		LSM_ENTRY_TYPE_BUTTON,
-	["LSM_ENTRY_TYPE_RADIOBUTTON"] = LSM_ENTRY_TYPE_RADIOBUTTON,
+	["LSM_ENTRY_TYPE_NORMAL"] =			LSM_ENTRY_TYPE_NORMAL,
+	["LSM_ENTRY_TYPE_DIVIDER"] = 		LSM_ENTRY_TYPE_DIVIDER,
+	["LSM_ENTRY_TYPE_HEADER"] = 		LSM_ENTRY_TYPE_HEADER,
+	["LSM_ENTRY_TYPE_SUBMENU"] = 		LSM_ENTRY_TYPE_SUBMENU,
+	["LSM_ENTRY_TYPE_CHECKBOX"] =		LSM_ENTRY_TYPE_CHECKBOX,
+	["LSM_ENTRY_TYPE_BUTTON"] =			LSM_ENTRY_TYPE_BUTTON,
+	["LSM_ENTRY_TYPE_RADIOBUTTON"] = 	LSM_ENTRY_TYPE_RADIOBUTTON,
 }
 local scrollListRowTypes = lib.scrollListRowTypes
 
@@ -210,7 +214,7 @@ local scrollListRowTypes = lib.scrollListRowTypes
 for key, value in pairs(scrollListRowTypes) do
 	--Create the lib.LSM_ENTRY_TYPE* variables
 	lib[key] = value
-	--Create the LSM_ENTRY_TYPE_NORMAL globals
+	--Create the LSM_ENTRY_TYPE*L globals
 	_G[key] = value
 end
 
@@ -222,52 +226,73 @@ local entryTypeToButtonChildName = {
 
 --Used in API RunCustomScrollableMenuItemsCallback and comboBox_base:AddCustomEntryTemplates to validate passed in entryTypes
 local libraryAllowedEntryTypes = {
-	[LSM_ENTRY_TYPE_NORMAL] = 	true,
-	[LSM_ENTRY_TYPE_DIVIDER] = 	true,
-	[LSM_ENTRY_TYPE_HEADER] = 	true,
-	[LSM_ENTRY_TYPE_SUBMENU] =	true,
-	[LSM_ENTRY_TYPE_CHECKBOX] =	true,
-	[LSM_ENTRY_TYPE_BUTTON] =	true,
+	[LSM_ENTRY_TYPE_NORMAL] = 		true,
+	[LSM_ENTRY_TYPE_DIVIDER] = 		true,
+	[LSM_ENTRY_TYPE_HEADER] = 		true,
+	[LSM_ENTRY_TYPE_SUBMENU] =		true,
+	[LSM_ENTRY_TYPE_CHECKBOX] =		true,
+	[LSM_ENTRY_TYPE_BUTTON] =		true,
 	[LSM_ENTRY_TYPE_RADIOBUTTON] =	true,
 }
---lib.allowedEntryTypes = libraryAllowedEntryTypes
+lib.AllowedEntryTypes = libraryAllowedEntryTypes
 
 --Used in API AddCustomScrollableMenuEntry to validate passed in entryTypes to be allowed for the contextMenus
 local allowedEntryTypesForContextMenu = {
-	[LSM_ENTRY_TYPE_NORMAL] = 	true,
-	[LSM_ENTRY_TYPE_DIVIDER] = 	true,
-	[LSM_ENTRY_TYPE_HEADER] = 	true,
-	[LSM_ENTRY_TYPE_SUBMENU] =	true,
-	[LSM_ENTRY_TYPE_CHECKBOX] = true,
-	[LSM_ENTRY_TYPE_BUTTON] = true,
-	[LSM_ENTRY_TYPE_RADIOBUTTON] = true,
+	[LSM_ENTRY_TYPE_NORMAL] = 		true,
+	[LSM_ENTRY_TYPE_DIVIDER] = 		true,
+	[LSM_ENTRY_TYPE_HEADER] = 		true,
+	[LSM_ENTRY_TYPE_SUBMENU] =		true,
+	[LSM_ENTRY_TYPE_CHECKBOX] = 	true,
+	[LSM_ENTRY_TYPE_BUTTON] = 		true,
+	[LSM_ENTRY_TYPE_RADIOBUTTON] = 	true,
 }
---lib.allowedEntryTypesForContextMenu = allowedEntryTypesForContextMenu
+lib.AllowedEntryTypesForContextMenu = allowedEntryTypesForContextMenu
 
 --Used in API AddCustomScrollableMenuEntry to validate passed in entryTypes to be used without a callback function
+--provided (else the assert raises an error)
 local entryTypesForContextMenuWithoutMandatoryCallback = {
-	[LSM_ENTRY_TYPE_DIVIDER] = 	true,
-	[LSM_ENTRY_TYPE_HEADER] = 	true,
-	[LSM_ENTRY_TYPE_SUBMENU] =	true,
+	[LSM_ENTRY_TYPE_DIVIDER] = 		true,
+	[LSM_ENTRY_TYPE_HEADER] = 		true,
+	[LSM_ENTRY_TYPE_SUBMENU] =		true,
 }
---lib.entryTypesForContextMenuWithoutMandatoryCallback = entryTypesForContextMenuWithoutMandatoryCallback
 
+--Table additionalData's key (e.g. isDivider) to the LSM entry type mapping
+local additionalDataKeyToLSMEntryType = {
+	["isDivider"] = 	LSM_ENTRY_TYPE_DIVIDER,
+	["isHeader"] = 		LSM_ENTRY_TYPE_HEADER,
+	["isCheckbox"] =	LSM_ENTRY_TYPE_CHECKBOX,
+	["isButton"] = 		LSM_ENTRY_TYPE_BUTTON,
+	["isRadioButton"] = LSM_ENTRY_TYPE_RADIOBUTTON,
+}
+
+
+------------------------------------------------------------------------------------------------------------------------
 --Row highlights (on mouse enter)
 local LSM_ROW_HIGHLIGHT_DEFAULT = 	'ZO_SelectionHighlight'
 local LSM_ROW_HIGHLIGHT_GREEN = 	'LibScrollableMenu_Highlight_Green'
 local LSM_ROW_HIGHLIGHT_BLUE = 		'LibScrollableMenu_Highlight_Blue'
 local LSM_ROW_HIGHLIGHT_RED = 		'LibScrollableMenu_Highlight_Red'
 local LSM_ROW_HIGHLIGHT_OPAQUE = 	'LibScrollableMenu_Highlight_Opaque'
-lib.LSM_ROW_HIGHLIGHT_DEFAULT = 	LSM_ROW_HIGHLIGHT_DEFAULT
-lib.LSM_ROW_HIGHLIGHT_GREEN = 		LSM_ROW_HIGHLIGHT_GREEN
-lib.LSM_ROW_HIGHLIGHT_BLUE = 		LSM_ROW_HIGHLIGHT_BLUE
-lib.LSM_ROW_HIGHLIGHT_RED = 		LSM_ROW_HIGHLIGHT_RED
-lib.LSM_ROW_HIGHLIGHT_OPAQUE = 		LSM_ROW_HIGHLIGHT_OPAQUE
+lib.scrollListRowHighlights = {
+	["LSM_ROW_HIGHLIGHT_DEFAULT"] =		LSM_ROW_HIGHLIGHT_DEFAULT,
+	["LSM_ROW_HIGHLIGHT_GREEN"] = 		LSM_ROW_HIGHLIGHT_GREEN,
+	["LSM_ROW_HIGHLIGHT_BLUE"] = 		LSM_ROW_HIGHLIGHT_BLUE,
+	["LSM_ROW_HIGHLIGHT_RED"] = 		LSM_ROW_HIGHLIGHT_RED,
+	["LSM_ROW_HIGHLIGHT_OPAQUE"] =		LSM_ROW_HIGHLIGHT_OPAQUE,
+}
+local scrollListRowHighlights = lib.scrollListRowHighlights
+--The custom scrollable context menu row highlight types > Globals
+for key, value in pairs(scrollListRowHighlights) do
+	--Create the lib.LSM_ROW_HIGHLIGHT* variables
+	lib[key] = value
+	--Create the LSM_ROW_HIGHLIGHT* globals
+	_G[key] = value
+end
 
 --The default row highlight data for an entry having a submenu, where the entry itsself got a callback
 local defaultHighlightTemplateDataEntryHavingSubMenuWithCallback = {
-	template = LSM_ROW_HIGHLIGHT_GREEN, --green row
-	color = DEFAULT_TEXT_HIGHLIGHT,
+	template = 	LSM_ROW_HIGHLIGHT_GREEN, --green row
+	color = 	DEFAULT_TEXT_HIGHLIGHT,
 }
 
 
@@ -288,31 +313,23 @@ local LSMEntryKeyZO_ComboBoxEntryKey = {
 }
 
 ------------------------------------------------------------------------------------------------------------------------
---Table additionalData's key (e.g. isDivider) to the LSM entry type mapping
-local additionalDataKeyToLSMEntryType = {
-	["isCheckbox"] =	LSM_ENTRY_TYPE_CHECKBOX,
-	["isDivider"] = 	LSM_ENTRY_TYPE_DIVIDER,
-	["isHeader"] = 		LSM_ENTRY_TYPE_HEADER,
-	["isButton"] = 		LSM_ENTRY_TYPE_BUTTON,
-	["isRadioButton"] = LSM_ENTRY_TYPE_RADIOBUTTON,
-}
-
-
-------------------------------------------------------------------------------------------------------------------------
 --Entries which can use a function and need to be updated via function updateDataValues
-
 --Table contains [string key] = defaultValue boolean for the row/entry's data table
 --> If key inside the row's data table (e.g. data["name"]) is a function:
---> This function will be added to row's data._LSM.funcData subtables and executed upon showing the LSM dropdown.
---> If the functions return value is nil it will use the value of this table below, if it is true (false oothers will be ignored)
+--> This function will be added to row's data._LSM.funcData subtables (see function updateDataValues) and executed upon
+--> showing the LSM dropdown.
+--> If the functions return value is nil it will use the value of this table below, if it is true (false/others will be ignored)
 local nilToTrue = true
 local nilIgnore = false
 local possibleEntryDataWithFunction = {
+	--Ignored entryDatas: Returning nil by default
 	["name"] = 		nilIgnore,
 	["label"] = 	nilIgnore,
 	["checked"] = 	nilIgnore,
-	["enabled"] = 	nilToTrue,
 	["font"] = 		nilIgnore,
+
+	--entryData returning true by default
+	["enabled"] = 	nilToTrue,
 }
 
 
@@ -323,6 +340,7 @@ local possibleEntryDataWithFunction = {
 --dropdown helper classes
 local comboBoxDefaults = {
 	--From ZO_ComboBox
+	---member data with m_
 	m_selectedItemData = 			nil,
 	m_selectedColor =				{ GetInterfaceColor(INTERFACE_COLOR_TYPE_TEXT_COLORS, INTERFACE_TEXT_COLOR_SELECTED) },
 	m_disabledColor = 				DEFAULT_TEXT_DISABLED_COLOR,
@@ -340,12 +358,17 @@ local comboBoxDefaults = {
 	m_enableMultiSelect = 			false,
 	m_maxNumSelections = 			nil,
 	m_height = 						DEFAULT_HEIGHT,
-	horizontalAlignment = 			TEXT_ALIGN_LEFT,
-	itemYPad = 						0, --LibScrollableMenu support
 
-	--LibScrollableMenu internal (e.g. .options)
+	--non member data
+	horizontalAlignment = 			TEXT_ALIGN_LEFT,
+
+	--LibCustomMenu support
+	itemYPad = 						0,
+
+	--LibScrollableMenu internal (e.g. options)
 	disableFadeGradient = 			false,
-	m_headerFontColor = 			HEADER_TEXT_COLOR,
+	headerFont =					DEFAULT_FONT,
+	headerColor = 					HEADER_TEXT_COLOR,
 	visibleRows = 					DEFAULT_VISIBLE_ROWS,
 	visibleRowsSubmenu = 			DEFAULT_VISIBLE_ROWS,
 	baseEntryHeight = 				ZO_COMBO_BOX_ENTRY_TEMPLATE_HEIGHT,
@@ -359,16 +382,16 @@ local defaultHighlightColor = comboBoxDefaults.m_highlightColor
 
 --The default values for dropdownHelper options -> used for non-passed in options at LSM API functions
 local defaultComboBoxOptions  = {
+	["disableFadeGradient"] = 		false,
+	["font"] = 						DEFAULT_FONT,
+	["headerCollapsed"] =			false,
+	["headerCollapsible"] = 		false,
+	["highlightContextMenuOpeningControl"] = false,
+	["sortEntries"] = 				DEFAULT_SORTS_ENTRIES,
+	["spacing"] = 					DEFAULT_SPACING,
+	["useDefaultHighlightForSubmenuWithCallback"] = false,
 	["visibleRowsDropdown"] = 		DEFAULT_VISIBLE_ROWS,
 	["visibleRowsSubmenu"] = 		DEFAULT_VISIBLE_ROWS,
-	["sortEntries"] = 				DEFAULT_SORTS_ENTRIES,
-	["font"] = 						DEFAULT_FONT,
-	["spacing"] = 					DEFAULT_SPACING,
-	["disableFadeGradient"] = 		false,
-	["useDefaultHighlightForSubmenuWithCallback"] = false,
-	["highlightContextMenuOpeningControl"] = false,
-	["headerCollapsible"] = 		false,
-	["headerCollapsed"] =			false,
 	--["XMLRowTemplates"] = 		table, --Will be set at comboBoxClass:UpdateOptions(options) from options (see function comboBox_base:AddCustomEntryTemplates)
 	--["XMLRowHighlightTemplates"] =table, --Will be set at comboBoxClass:UpdateOptions(options) from options (see function comboBox_base:AddCustomEntryTemplates)
 }
@@ -378,38 +401,40 @@ lib.defaultComboBoxOptions  = defaultComboBoxOptions
 ------------------------------------------------------------------------------------------------------------------------
 --Options key mapping
 
---The mapping between LibScrollableMenu options key and ZO_ComboBox options key. Used in comboBoxClass:UpdateOptions()
+--The mapping between LibScrollableMenu options key and ZO_ComboBox's key. Used in comboBoxClass:UpdateOptions()
 local LSMOptionsKeyToZO_ComboBoxOptionsKey = {
 	--All possible options entries "must" be mapped here (left: options entry / right: ZO_ComboBox relating entry where the value is saved)
 	-->e.g. options.visibleRowsDropdown -> Will be saved at comboBox.visibleRows (and if a function in table LSMOptionsToZO_ComboBoxOptionsCallbacks
 	-->is defiend below this function will be executed too).
 	-->Missing entries (even if names are the same) will relate in function comboBoxClass:SetOption not respecting the value!
 	["disableFadeGradient"] =	"disableFadeGradient", --Used for the ZO_ScrollList of the dropdown, not the comboBox itsself
-	["headerColor"] =			"m_headerFontColor",
-	["normalColor"] = 			"m_normalColor",
 	["disabledColor"] =			"m_disabledColor",
-	["visibleRowsSubmenu"]=		"visibleRowsSubmenu",
-	["titleText"] = 			"titleText",
-	["titleFont"] = 			"titleFont",
-	["subtitleText"] = 			"subtitleText",
-	["subtitleFont"] = 			"subtitleFont",
-	["titleTextAlignment"] =	"titleTextAlignment",
 	["enableFilter"] =			"enableFilter",
-	["narrate"] = 				"narrateData",
-	["maxDropdownHeight"] =		"maxHeight",
-	["useDefaultHighlightForSubmenuWithCallback"] = "useDefaultHighlightForSubmenuWithCallback",
-	["highlightContextMenuOpeningControl"] = "highlightContextMenuOpeningControl",
 	["headerCollapsible"] = 	"headerCollapsible",
 	["headerCollapsed"] = 		"headerCollapsed",
+	["headerColor"] =			"headerColor",
+	["headerFont"] =			"headerFont",
+	["highlightContextMenuOpeningControl"] = "highlightContextMenuOpeningControl",
+	["narrate"] = 				"narrateData",
+	["normalColor"] = 			"m_normalColor",
+	["subtitleText"] = 			"subtitleText",
+	["subtitleFont"] = 			"subtitleFont",
+	["titleFont"] = 			"titleFont",
+	["titleText"] = 			"titleText",
+	["titleTextAlignment"] =	"titleTextAlignment",
+	["useDefaultHighlightForSubmenuWithCallback"] = "useDefaultHighlightForSubmenuWithCallback",
+	["visibleRowsSubmenu"]=		"visibleRowsSubmenu",
 
 	--Entries with callback function -> See table "LSMOptionsToZO_ComboBoxOptionsCallbacks" below
-	-->!!!Attention: Add the entries, which you add as callback function to table "LSMOptionsToZO_ComboBoxOptionsCallbacks" below, in this table here too!!!
-	['sortType'] = 				"m_sortType",
-	['sortOrder'] = 			"m_sortOrder",
-	['sortEntries'] = 			"m_sortsItems",
-	['spacing'] = 				"m_spacing",
+	-->!!!Attention: You must add those entries, which you add as callback function to table "LSMOptionsToZO_ComboBoxOptionsCallbacks",
+	-->to this table LSMOptionsKeyToZO_ComboBoxOptionsKey here too!!!
 	['font'] = 					"m_font",
+	['maxDropdownHeight'] =		"maxHeight",
 	["preshowDropdownFn"] = 	"m_preshowDropdownFn",
+	['sortEntries'] = 			"m_sortsItems",
+	['sortOrder'] = 			"m_sortOrder",
+	['sortType'] = 				"m_sortType",
+	['spacing'] = 				"m_spacing",
 	["visibleRowsDropdown"] =	"visibleRows",
 }
 lib.LSMOptionsKeyToZO_ComboBoxOptionsKey = LSMOptionsKeyToZO_ComboBoxOptionsKey
@@ -417,14 +442,22 @@ lib.LSMOptionsKeyToZO_ComboBoxOptionsKey = LSMOptionsKeyToZO_ComboBoxOptionsKey
 --The callback functions for the mapped LSM option -> ZO_ComboBox options (where any provided/needed)
 local LSMOptionsToZO_ComboBoxOptionsCallbacks = {
 	--These callback functions will apply the options directly
-	['sortType'] = function(comboBoxObject, sortType)
-		local options = comboBoxObject.options
-		local updatedOptions = comboBoxObject.updatedOptions
-		if updatedOptions.sortOrder then return end
+	--If self. (= comboBoxObject) updatedOptions table is provided it might contain already processed
+	--"updated" options of the current loop at self:UpdateOptions(optionsTable)
+	-->You can use these table entries to get the most up2date values of the currently processed options
 
-		local sortOrder = getValueOrCallback(options.sortOrder, options)
-		if sortOrder == nil then sortOrder = comboBoxObject.m_sortOrder end
-		comboBoxObject:SetSortOrder(sortType , sortOrder )
+	['font'] = function(comboBoxObject, font)
+		comboBoxObject:SetFont(font) --sets comboBoxObject.m_font
+	end,
+	["maxDropdownHeight"] = function(comboBoxObject, maxDropdownHeight)
+		comboBoxObject.maxHeight = maxDropdownHeight
+		comboBoxObject:UpdateHeight(comboBoxObject.m_dropdown)
+	end,
+	["preshowDropdownFn"] = function(comboBoxObject, preshowDropdownCallbackFunc)
+		comboBoxObject:SetPreshowDropdownCallback(preshowDropdownCallbackFunc) --sets m_preshowDropdownFn
+	end,
+	["sortEntries"] = function(comboBoxObject, sortEntries)
+		comboBoxObject:SetSortsItems(sortEntries) --sets comboBoxObject.m_sortsItems
 	end,
 	['sortOrder'] = function(comboBoxObject, sortOrder)
 		local options = comboBoxObject.options
@@ -436,24 +469,22 @@ local LSMOptionsToZO_ComboBoxOptionsCallbacks = {
 		local sortType = getValueOrCallback(options.sortType, options) or comboBoxObject.m_sortType
 		comboBoxObject:SetSortOrder(sortType , sortOrder)
 	end,
-	["sortEntries"] = function(comboBoxObject, sortEntries)
-		comboBoxObject:SetSortsItems(sortEntries) --sets comboBoxObject.m_sortsItems
+	['sortType'] = function(comboBoxObject, sortType)
+		local options = comboBoxObject.options
+		--Check if any updatedOptions already exist and if the sortOrder was updated already then sortType does not need
+		--to be updated too (and vice versa)
+		local updatedOptions = comboBoxObject.updatedOptions
+		if updatedOptions.sortOrder then return end
+
+		local sortOrder = getValueOrCallback(options.sortOrder, options)
+		if sortOrder == nil then sortOrder = comboBoxObject.m_sortOrder end
+		comboBoxObject:SetSortOrder(sortType , sortOrder )
 	end,
 	['spacing'] = function(comboBoxObject, spacing)
 		comboBoxObject:SetSpacing(spacing) --sets comboBoxObject.m_spacing
 	end,
-	['font'] = function(comboBoxObject, font)
-		comboBoxObject:SetFont(font) --sets comboBoxObject.m_font
-	end,
-	["preshowDropdownFn"] = function(comboBoxObject, preshowDropdownCallbackFunc)
-		comboBoxObject:SetPreshowDropdownCallback(preshowDropdownCallbackFunc) --sets m_preshowDropdownFn
-	end,
 	["visibleRowsDropdown"] = function(comboBoxObject, visibleRows)
 		comboBoxObject.visibleRows = visibleRows
-		comboBoxObject:UpdateHeight(comboBoxObject.m_dropdown)
-	end,
-	["maxDropdownHeight"] = function(comboBoxObject, maxDropdownHeight)
-		comboBoxObject.maxHeight = maxDropdownHeight
 		comboBoxObject:UpdateHeight(comboBoxObject.m_dropdown)
 	end,
 }
@@ -502,11 +533,11 @@ local submenuClass_exposedVariables = {
 	---------------------------------------
 	['options'] = true,
 	['narrateData'] = true,
-	['m_headerFont'] = true,
 	['XMLRowTemplates'] = true, --TODO: is this being overwritten?
 	['XMLRowHighlightTemplates'] = true, --TODO: is this being overwritten?
 	['maxDropdownHeight'] = true,
-	['m_headerFontColor'] = true,
+	['headerFont'] = true,
+	['headerColor'] = true,
 	['m_highlightTemplate'] = true,
 	['visibleRowsSubmenu'] = true, -- we only need this "visibleRowsSubmenu" for the submenus, mainMenu uses visibleRowsDropdown
 	['disableFadeGradient'] = true,
@@ -1588,8 +1619,8 @@ local postItemSetupFunctions = {
 		itemEntry.isNew = recursiveOverEntries(itemEntry, preUpdateSubItems, nil)
 	end,
 	[LSM_ENTRY_TYPE_HEADER] = function(comboBox, itemEntry)
-		itemEntry.font = itemEntry.font or comboBox.m_headerFont
-		itemEntry.color = itemEntry.color or comboBox.m_headerFontColor
+		itemEntry.font = comboBox.headerFont or itemEntry.font
+		itemEntry.color = comboBox.headerColor or itemEntry.color
 	end,
 	[LSM_ENTRY_TYPE_DIVIDER] = function(comboBox, itemEntry)
 		itemEntry.name = libDivider
@@ -3736,10 +3767,11 @@ end
 
 --Get the current row's highlight template based on the options
 function comboBox_base:GetHighLightTemplate(control, isSubMenu)
+d("[LSM]comboBox_base:GetHighLightTemplate - control: " .. tos(getControlName(control)))
 	--Get the highlight template based on the entryType
 	local entryType = control.typeId
 	if not entryType then return end
-	local highlightTemplateData = ZO_ShallowTableCopy(self.XMLRowHighlightTemplates[entryType]) --loose the reference so we can overwrite values without changign originals
+	local highlightTemplateData = ZO_ShallowTableCopy(self.XMLRowHighlightTemplates[entryType]) --loose the reference so we can overwrite values without changing originals
 
 	if isSubMenu and control.closeOnSelect then
 		local options = self:GetOptions()
@@ -4452,6 +4484,8 @@ function comboBoxClass:SetOption(LSMOptionsKey)
 	if newValue == nil then return end
 
 	--Filling the self.updatedOptions table with values so they can be used in the callback functions (if any is given)
+	--from table LSMOptionsToZO_ComboBoxOptionsCallbacks
+	-->e.g. used for sortOrder and sortType
 	self.updatedOptions[LSMOptionsKey] = newValue
 
 	--Do we need to run a callback function to set the updated value?
@@ -4479,10 +4513,10 @@ function comboBoxClass:UpdateOptions(options, onInit)
 		optionsChanged = false
 	else
 		--self.optionsChanged might have been set by contextMenuClass:SetOptions(options) already. Check that first and keep that boolean state as we
-		--do not use self.options but self.optionsData here:
-		--->Coming from contextMenuClass:ShowContextMenu() -> self.optionsData was set via contextMenuClass:SetOptions(options) before, and will be passed in here
-		--->to UpdateOptions(options) as options parameter. self.optionsChanged will be true if the options changed at the contex menu (compared to old self.optionsData)
-		---->self.optionsData  is then used at OnShow of the context menu. That's why we cannot compare the self.options here!
+		--do not use self.options for the context menus, but self.contextMenuOptions here:
+		--->Coming from contextMenuClass:ShowContextMenu() -> self.contextMenuOptions was set via contextMenuClass:SetOptions(options) before, and will be passed in here
+		--->to UpdateOptions(options) as options parameter. self.optionsChanged will be true if the options changed at the contex menu (compared to old self.contextMenuOptions)
+		---->self.contextMenuOptions is then used at OnShow of the context menu.
 		--
 		--For other "non-context menu" calls: Compare the already stored self.options table to the new passed in options table (both could be nil though)
 		optionsChanged = optionsChanged or options ~= self.options
@@ -4494,6 +4528,7 @@ function comboBoxClass:UpdateOptions(options, onInit)
 	--> Reset to default ZO_ComboBox variables and just call AddCustomEntryTemplates()
 	if (optionsChanged == true or onInit == true) and ZO_IsTableEmpty(options) then
 		optionsChanged = false
+--d(">>resetting options to defaults!")
 		self:ResetToDefaults() -- Reset comboBox internal variables of ZO_ComboBox, e.g. m_font, and LSM defaults like visibleRowsDropdown
 
 	--Did the options change: Yes / OR Are the already stored options at the object nil or empty (should happen if self:UpdateOptions(options) was not called before): Yes
@@ -4513,6 +4548,9 @@ function comboBoxClass:UpdateOptions(options, onInit)
 		self:SetOptions(options)
 
 		--Clear the table with options which got updated. Will be filled in self:SetOption(key) method
+		-->Filling the self.updatedOptions table with values so they can be used in the callback functions (if any is given)
+		-->from table LSMOptionsToZO_ComboBoxOptionsCallbacks, e.g. sortOrder and sortType can check if either was updated already
+		-->via the loop and self:SetOption() calls below
 		self.updatedOptions = {}
 
 		-- Defaults are predefined in defaultComboBoxOptions, but they will be taken from ZO_ComboBox defaults set from table comboBoxDefaults
@@ -4521,12 +4559,15 @@ function comboBoxClass:UpdateOptions(options, onInit)
 		-- was overwriting it here from passed in options table
 
 		-- LibScrollableMenu custom options
-		for key, _ in pairs(options) do
---d(">>setting option key: " ..tos(key))
-			self:SetOption(key)
+		if not ZO_IsTableEmpty(options) then
+			for key, _ in pairs(options) do
+				--d(">>setting option key: " ..tos(key))
+				self:SetOption(key)
+			end
 		end
 
-		--Reset the table with options which got updated
+		--Reset the table with options which got updated (only needed here for the callback functions called from self:SetOption
+		---> See table LSMOptionsToZO_ComboBoxOptionsCallbacks
 		self.updatedOptions = nil
 
 --d("> SetOption and for ... do SetOptions looped ")
@@ -4796,7 +4837,7 @@ function contextMenuClass:AddMenuItems(parentControl, comingFromFilters)
 end
 
 function contextMenuClass:ClearItems()
-	--d( debugPrefix .. 'contextMenuClass:ClearItems()')
+d(debugPrefix .. 'contextMenuClass:ClearItems()')
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 152) end
 	self:SetContextMenuOptions(nil)
 	self:ResetToDefaults()
@@ -4842,15 +4883,15 @@ end
 function contextMenuClass:ShowContextMenu(parentControl)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 157, tos(getControlName(parentControl))) end
 
-d("[LSM]contextMenuClass:ShowContextMenu")
-
+--d("[LSM]->->->->-> contextMenuClass:ShowContextMenu")
+	--Cache last opening Control for the comparison with new openingControl and reset of filters etc. below
 	local openingControlOld = self.openingControl
 	self.openingControl = parentControl
 
+	-- To prevent the context menu from overlapping a submenu it is not opened from:
+	-- If the opening control is a dropdown and has a submenu visible, close the submenu.
 	local comboBox = getComboBox(parentControl)
 	if comboBox and comboBox.m_submenu and comboBox.m_submenu:IsDropdownVisible() then
-		-- To prevent the context menu from overlapping a submenu it is not opened from,
-		-- If the opening control is a dropdown and has a submenu visible, close the submenu.
 		comboBox.m_submenu:HideDropdown()
 	end
 
@@ -4858,12 +4899,13 @@ d("[LSM]contextMenuClass:ShowContextMenu")
 		self:HideDropdown()
 	end
 
-	self:UpdateOptions(self.optionsData)
+	self:UpdateOptions(self.contextMenuOptions)
 
 
---d("[LSM]ctxMen-optionsData.highlightContextMenuOpeningControl: " ..tos(self.optionsData.highlightContextMenuOpeningControl))
+--d("[LSM]ctxMen-contextMenuOptions.highlightContextMenuOpeningControl: " ..tos(self.contextMenuOptions.highlightContextMenuOpeningControl))
 	if self.openingControl then
-		if self.optionsData.highlightContextMenuOpeningControl then
+		--Options tell us to highlight the openingControl?
+		if self.contextMenuOptions.highlightContextMenuOpeningControl then
 			highlightControl(self, self.openingControl)
 		end
 	end
@@ -4887,16 +4929,13 @@ end
 function contextMenuClass:SetContextMenuOptions(options)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 158, tos(options)) end
 
-	--[[ --todo 20240506 Still needed? If enabled again it would overwrite the context menu options with defaults (which should be okay?)
-	if ZO_IsTableEmpty(options) then
-		self:ResetToDefaults()
-	end
-	]]
+	-- self.contextMenuOptions is only a temporary table used to check for changes and to send to UpdateOptions
+	-- so we can check here if anything changed within the passed in options paramter (compared to previous options)
+	self.optionsChanged = self.contextMenuOptions ~= options
 
-	-- self.optionsData is only a temporary table used to check for changes and to send to UpdateOptions.
-	self.optionsChanged = self.optionsData ~= options
-d("[LSM]contextMenuClass:SetContextMenuOptions - optionsChanged: " .. tos(self.optionsChanged))
-	self.optionsData = options
+	--d("[LSM]contextMenuClass:SetContextMenuOptions - optionsChanged: " .. tos(self.optionsChanged))
+	--Wil be used in contextMenuClass:ShowContextMenu -> self:UpdateOptions(self.contextMenuOptions)
+	self.contextMenuOptions = options
 end
 
 --Create the local context menu object for the library's context menu API functions
@@ -4941,6 +4980,7 @@ end
 -- 		string font:optional				 	String or function returning a string: font to use for the dropdown entries
 -- 		number spacing:optional,	 			Number or function returning a Number: Spacing between the entries
 --		boolean disableFadeGradient:optional	Boolean or function returning a boolean: for the fading of the top/bottom scrolled rows
+--		string headerFont:optional				String or function returning a string: font to use for the header entries
 --		table headerColor:optional				table (ZO_ColorDef) or function returning a color table with r, g, b, a keys and their values: for header entries
 --		table normalColor:optional				table (ZO_ColorDef) or function returning a color table with r, g, b, a keys and their values: for all normal (enabled) entries
 --		table disabledColor:optional 			table (ZO_ColorDef) or function returning a color table with r, g, b, a keys and their values: for all disabled entries
@@ -5197,24 +5237,19 @@ end
 --Set the options (visible rows max, etc.) for the scrollable context menu, or any passed in 2nd param comboBoxContainer
 -->See possible options above AddCustomScrollableComboBoxDropdownMenu
 function SetCustomScrollableMenuOptions(options, comboBoxContainer)
-	--local optionsTableType = type(options)
-	--assert(optionsTableType == 'table' , sfor('['..MAJOR..':SetCustomScrollableMenuOptions] table expected, got %q = %s', "options", tos(optionsTableType)))
-
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 167, tos(getControlName(comboBoxContainer)), tos(options)) end
-
-
-df("[LSM]SetCustomScrollableMenuOptions - comboBoxContainer: %s, options: %s", tos(getControlName(comboBoxContainer)), tos(options))
+--df("[LSM]SetCustomScrollableMenuOptions - comboBoxContainer: %s, options: %s", tos(getControlName(comboBoxContainer)), tos(options))
 
 	--Use specified comboBoxContainer's dropdown to update the options to
 	if comboBoxContainer ~= nil then
 		local comboBox = ZO_ComboBox_ObjectFromContainer(comboBoxContainer)
 		if comboBox ~= nil and comboBox.UpdateOptions then
 			comboBox.optionsChanged = options ~= comboBox.options
-d(">SetCustomScrollableMenuOptions - Found UpdateOptions - optionsChanged: " ..tos(comboBox.optionsChanged))
+--d(">comboBox:UpdateOptions -> optionsChanged: " ..tos(comboBox.optionsChanged))
 			comboBox:UpdateOptions(options)
 		end
 	else
-d(">SetContextMenuOptions")
+--d(">g_contextMenu:SetContextMenuOptions")
 		--Update options to default contextMenu
 		g_contextMenu:SetContextMenuOptions(options)
 	end
@@ -5223,6 +5258,7 @@ local setCustomScrollableMenuOptions = SetCustomScrollableMenuOptions
 
 --Hide the custom scrollable context menu and clear it's entries, clear internal variables, mouse clicks etc.
 function ClearCustomScrollableMenu()
+--d("[LSM]<<<<<< ClearCustomScrollableMenu <<<<<<<<<<<<<")
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 168) end
 	hideContextMenu()
 
@@ -5292,13 +5328,18 @@ end
 --Existing context menu entries will be kept (until ClearCustomScrollableMenu will be called)
 function ShowCustomScrollableMenu(controlToAnchorTo, options)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 171, tos(getControlName(controlToAnchorTo)), tos(options)) end
-df("_-_-_-_-_-_-_-_-_-_ [LSM]ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
+	--df("[LSM]_-_-_-_-_ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
 
 	--Fire the OnDropdownMenuAdded callback where one can replace options in the options table -> Here: For the contextMenu
-	lib:FireCallbacks('OnDropdownMenuAdded', g_contextMenu, options)
+	local optionsForCallbackFire = options or {}
+	lib:FireCallbacks('OnDropdownMenuAdded', g_contextMenu, optionsForCallbackFire)
+	if optionsForCallbackFire ~= options then
+		options = optionsForCallbackFire
+	end
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG_CALLBACK, 172, tos(getControlName(g_contextMenu.m_container)), tos(options)) end
-	if options then
-d(">calling SetCustomScrollableMenuOptions")
+
+	if options ~= nil then
+		--d(">calling SetCustomScrollableMenuOptions")
 		setCustomScrollableMenuOptions(options)
 	end
 
@@ -5306,6 +5347,7 @@ d(">calling SetCustomScrollableMenuOptions")
 	g_contextMenu:ShowContextMenu(controlToAnchorTo)
 	return true
 end
+local showCustomScrollableMenu = ShowCustomScrollableMenu
 
 --Run a callback function myAddonCallbackFunc passing in the entries of the opening menu/submneu of a clicked LSM context menu item
 -->Parameters of your function myAddonCallbackFunc must be:
@@ -5445,10 +5487,11 @@ local function buttonGroupDefaultContextMenu(comboBox, control, data)
 			end,
 		},
 	}
+
 	clearCustomScrollableMenu()
 	addCustomScrollableMenuEntries(buttonGroupSetAll)
-d("[LSM]>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> buttonGroupDefaultContextMenu")
-	ShowCustomScrollableMenu()
+--d("[LSM]°°°°°°°°°°°°°°°° showCustomScrollableMenu checkbox context menu")
+	showCustomScrollableMenu(nil, nil)
 end
 lib.SetButtonGroupState = buttonGroupDefaultContextMenu --Only for compatibilitxy (if any other addon was using 'SetButtonGroupState' already)
 lib.ButtonGroupDefaultContextMenu = buttonGroupDefaultContextMenu
@@ -5464,7 +5507,11 @@ lib.ButtonGroupDefaultContextMenu = buttonGroupDefaultContextMenu
 -- XML handler functions
 ------------------------------------------------------------------------------------------------------------------------
 --XML OnClick handler for checkbox and radiobuttons
-function lib.ButtonOnInitialize(control, isRadioButton)
+function lib.XMLButtonOnInitialize(control, entryType)
+	--Which XML button control's handler was used, checkbox or radiobutton?
+	local isCheckbox = entryType == LSM_ENTRY_TYPE_CHECKBOX
+	local isRadioButton = not isCheckbox and entryType == LSM_ENTRY_TYPE_RADIOBUTTON
+
 	control:GetParent():SetHandler('OnMouseUp', function(parent, buttonId, upInside, ...)
 --d(debugPrefix .. "OnMouseUp of parent-upInside: " ..tos(upInside) .. ", buttonId: " .. tos(buttonId))
 		if upInside then
@@ -5475,7 +5522,6 @@ function lib.ButtonOnInitialize(control, isRadioButton)
 
 				local onClickedHandler = control:GetHandler('OnClicked')
 				if onClickedHandler then
---d("[LSM]RB: OnClickedHandler: " ..tos(onClickedHandler))
 					onClickedHandler(control, buttonId)
 				end
 
@@ -5494,27 +5540,16 @@ function lib.ButtonOnInitialize(control, isRadioButton)
 	if not isRadioButton then
 		local originalClicked = control:GetHandler('OnClicked')
 		control:SetHandler('OnClicked', function(p_control, buttonId, ignoreCallback, skipHiddenForReasonsCheck, ...)
-			local parent = p_control:GetParent()
-			local comboBox = parent.m_owner
 			skipHiddenForReasonsCheck = skipHiddenForReasonsCheck or false
-
 			if not skipHiddenForReasonsCheck then
+				local parent = p_control:GetParent()
+				local comboBox = parent.m_owner
 				if checkIfContextMenuOpenedButOtherControlWasClicked(p_control, comboBox, buttonId) == true then return end
 			end
 
-			--local dropdown = control:GetOwningWindow().m_dropdownObject
-			--playSelectedSoundCheck(dropdown, LSM_ENTRY_TYPE_CHECKBOX)
-			--if p_control.checked ~= nil then
-				--cBox contextmenu: Enable all/Disable all get's here
---d(">1 ZO_CheckButton_SetCheckState - checked: " ..tos(p_control.checked))
-				--ZO_CheckButton_SetCheckState(p_control, p_control.checked)
-			--else
-				--cBox contextmenu: Invert get's here
-				if originalClicked then
---d(">2 originalClicked")
-					originalClicked(p_control, buttonId, ignoreCallback, ...)
-				end
-			--end
+			if originalClicked then
+				originalClicked(p_control, buttonId, ignoreCallback, ...)
+			end
 			p_control.checked = nil
 		end)
 	end
@@ -5609,15 +5644,16 @@ WORKING ON - Current version: 2.33 - Updated 2024-12-16
 -------------------
 	1. Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 	2. Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
-	3. Renamed API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
-	4. Contextmenu API functions return the index/indices of added entry/entries and boolean values (where applicable)
-	5. Changed XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
+	3. Renamed: API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
+	4. Changed: Contextmenu API functions return the index/indices of added entry/entries and boolean values (where applicable)
+	5. Changed: XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
 	6. Fixed XMLRowTemplates using a non capital R at some locations
-	7. Handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
-	8. Added options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType
+	7. Changed: Handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
+	8. Added: options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType
 	9. Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
 	10. Changed: Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled
-	11. Bug: todo 20241221 Default context menu "'buttonGroupDefaultContextMenu'" for checkboxes (Select all, Select none, Invert) dioes not apply the custom row highlight data on first open
+	11. Renamed: self.optionsData at contextMenus was properly renamed to self.contextMenuOptions
+	12. Bug fix: options.headerFont and headerColor work now
 
 -------------------
 TODO - To check (future versions)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -3534,19 +3534,11 @@ function comboBox_base:AddCustomEntryTemplates(options)
 		end
 	end
 
-	--Update the current object's rowHeight for the different entryTypes
+	--Update the current object's rowHeight (normal entry type)
 	local normalEntryHeight = XMLrowTemplatesToUse[LSM_ENTRY_TYPE_NORMAL].rowHeight
-	--[[ todo: 20240506 Is tis still needed?
-	self.XMLrowHeights = self.XMLrowHeights or {}
-	self.XMLrowHeights[LSM_ENTRY_TYPE_NORMAL] = 			normalEntryHeight
-	self.XMLrowHeights[LSM_ENTRY_TYPE_DIVIDER] = 	XMLrowTemplatesToUse[LSM_ENTRY_TYPE_DIVIDER].rowHeight
-	self.XMLrowHeights[LSM_ENTRY_TYPE_HEADER] = 	XMLrowTemplatesToUse[LSM_ENTRY_TYPE_HEADER].rowHeight
-	]]
-
 	-- We will use this, per-comboBox, to set max rows.
 	self.baseEntryHeight = normalEntryHeight
-
-	dLog(LSM_LOGTYPE_VERBOSE, ">NORMAL_ENTRY_HEIGHT %s, DIVIDER_ENTRY_HEIGHT: %s, HEADER_ENTRY_HEIGHT: %s", tos(normalEntryHeight), tos(XMLrowTemplatesToUse[LSM_ENTRY_TYPE_DIVIDER].rowHeight), tos(XMLrowTemplatesToUse[LSM_ENTRY_TYPE_HEADER].rowHeight))
+	dLog(LSM_LOGTYPE_VERBOSE, ">NORMAL_ENTRY_HEIGHT %s, DIVIDER_ENTRY_HEIGHT: %s, HEADER_ENTRY_HEIGHT: %s, CHECKBOX_ENTRY_HEIGHT: %s, BUTTON_ENTRY_HEIGHT: %s, RADIOBUTTON_ENTRY_HEIGHT: %s", tos(normalEntryHeight), tos(XMLrowTemplatesToUse[LSM_ENTRY_TYPE_DIVIDER].rowHeight), tos(XMLrowTemplatesToUse[LSM_ENTRY_TYPE_HEADER].rowHeight), tos(XMLrowTemplatesToUse[LSM_ENTRY_TYPE_CHECKBOX].rowHeight), tos(XMLrowTemplatesToUse[LSM_ENTRY_TYPE_BUTTON].rowHeight), tos(XMLrowTemplatesToUse[LSM_ENTRY_TYPE_RADIOBUTTON].rowHeight))
 end
 
 function comboBox_base:OnGlobalMouseUp(eventId, button)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -315,7 +315,7 @@ local comboBoxDefaults = {
 	m_font = 						DEFAULT_FONT,
 	m_normalColor = 				DEFAULT_TEXT_COLOR,
 	m_highlightColor = 				DEFAULT_TEXT_HIGHLIGHT,
-	m_highlightTemplate =			LSM_ROW_HIGHLIGHT_DEFAULT,
+	m_highlightTemplate =			LSM_ROW_HIGHLIGHT_DEFAULT, --ZO_SelectionHighlight
 	m_customEntryTemplateInfos =	nil,
 	m_enableMultiSelect = 			false,
 	m_maxNumSelections = 			nil,
@@ -383,7 +383,7 @@ local LSMOptionsKeyToZO_ComboBoxOptionsKey = {
 	["headerCollapsed"] = 		"headerCollapsed",
 
 	--Entries with callback function -> See table "LSMOptionsToZO_ComboBoxOptionsCallbacks" below
-	-->!!!Attention: Add the entries which you add as callback function to table "LSMOptionsToZO_ComboBoxOptionsCallbacks" below in this table here too!!!
+	-->!!!Attention: Add the entries, which you add as callback function to table "LSMOptionsToZO_ComboBoxOptionsCallbacks" below, in this table here too!!!
 	['sortType'] = 				"m_sortType",
 	['sortOrder'] = 			"m_sortOrder",
 	['sortEntries'] = 			"m_sortsItems",
@@ -2590,10 +2590,11 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	-->>!!! ZO_ScrollList_EnableHighlight(self.scrollControl, function(control) end) cannot be used here as it does NOT overwrite existing highlightTemplateOrFunction !!!
 	local selfVar = self
 	self.scrollControl.highlightTemplateOrFunction = function(control)
+d("[LSM]highlightTemplateOrFunction - control: " .. tos(getControlName(control)) .. ", owner: " .. tos(selfVar.owner))
 		if selfVar.owner then
 			return selfVar.owner:GetHighlightTemplate(control)
 		end
-		return comboBoxDefaults.m_highlightTemplate --'ZO_SelectionHighlight'
+		return defaultHighlightTemplate --'ZO_SelectionHighlight'
 	end
 end
 
@@ -3609,6 +3610,7 @@ function comboBox_base:AddCustomEntryTemplates(options)
 			end
 		end
 	end
+	--Will be used in comboBox_base:GetHighLightTemplate to get the template data for the rowType
 	self.XMLRowHighlightTemplates = XMLrowHighlightTemplatesToUse
 
 
@@ -3807,7 +3809,7 @@ end
 
 function comboBox_base:UpdateHighlightTemplate(control, isSubMenu)
 	local highlightTemplateData = self:GetHighLightTemplate(control, isSubMenu)
-d("[LSM]UpdateHighlightTemplate - name: " .. tos(getControlName(control)) .. ", entryType: " .. tos(control.typeId) .. "; HLtemplae: " .. tos(highlightTemplateData.template) .. "; color: " .. tos(highlightTemplateData.color))
+d("[LSM]UpdateHighlightTemplate - name: " .. tos(getControlName(control)) .. ", entryType: " .. tos(control.typeId) .. "; HL_Template: " .. tos(highlightTemplateData.template) .. "; color: " .. tos(highlightTemplateData.color))
 
 	if not highlightTemplateData then
 		control.m_data.m_highlightTemplate = nil

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -3006,6 +3006,22 @@ function dropdownClass:OnHide(formattedEventName)
 	end
 end
 
+--Called from XML "LibScrollableMenu_Dropdown_Behavior"
+function dropdownClass:XMLHandler(selfVar, handlerName)
+	if selfVar == nil or handlerName == nil then return end
+
+	if handlerName == "OnEffectivelyHidden" then
+		self:HideDropdown()
+	elseif handlerName == "OnMouseEnter" then
+		self:OnMouseExitTimeout(selfVar)
+
+	elseif handlerName == "OnShow" then
+		self:OnShow(self:GetFormattedNarrateEvent('Show'))
+	elseif handlerName == "OnHide" then
+		self:OnHide(self:GetFormattedNarrateEvent('Hide'))
+	end
+end
+
 function dropdownClass:ShowSubmenu(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 80, tos(getControlName(control))) end
 	if self.owner then
@@ -5251,6 +5267,9 @@ function SetCustomScrollableMenuOptions(options, comboBoxContainer)
 	--Use specified comboBoxContainer's dropdown to update the options to
 	if comboBoxContainer ~= nil then
 		local comboBox = ZO_ComboBox_ObjectFromContainer(comboBoxContainer)
+		if comboBox == nil and comboBoxContainer.m_dropdownObject ~= nil then
+			comboBox = ZO_ComboBox_ObjectFromContainer(comboBoxContainer.m_dropdownObject)
+		end
 		if comboBox ~= nil and comboBox.UpdateOptions then
 			comboBox.optionsChanged = options ~= comboBox.options
 --d(">comboBox:UpdateOptions -> optionsChanged: " ..tos(comboBox.optionsChanged))

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -3535,6 +3535,7 @@ local function getDefaultXMLTemplates(selfVar)
 		},
 		[LSM_ENTRY_TYPE_SUBMENU] = {
 			template = defaultHighlightTemplate,
+			templateWithCallback = LSM_ROW_HIGHLIGHT_GREEN, -- template for the entry where a submenu is opened but you can click the entry to call a callback too
 			color = defaultHighlightColor,
 		},
 		[LSM_ENTRY_TYPE_DIVIDER] = {
@@ -3597,12 +3598,12 @@ function comboBox_base:AddCustomEntryTemplates(options)
 	--Check if all XML row highlight templates are passed in, and update missing ones with default values
 	--or set the template/color that should be used for all of the entryTypes
 	if optionHighlightTemplates or customHighlightTemplateForAllEntryTypes or customHighlightColorForAllEntryTypes then
-d("[LSM]customHighlightTemplateForAll: " .. tos(customHighlightTemplateForAllEntryTypes) ..", customHighlightColorForAll: ".. tos(customHighlightColorForAllEntryTypes) ..", optionHighlightTemplates: " .. tos(options.XMLRowHighlightTemplates))
+--d("[LSM]customHighlightTemplateForAll: " .. tos(customHighlightTemplateForAllEntryTypes) ..", customHighlightColorForAll: ".. tos(customHighlightColorForAllEntryTypes) ..", optionHighlightTemplates: " .. tos(options.XMLRowHighlightTemplates))
 		for entryType, _ in pairs(defaultXMLHighlightTemplates) do
 			if customHighlightTemplateForAllEntryTypes ~= nil then
 				XMLrowHighlightTemplatesToUse[entryType].template = customHighlightTemplateForAllEntryTypes
 			elseif optionHighlightTemplates and optionHighlightTemplates[entryType] then
-d(">entryType: " .. tos(entryType) ..", customHighlightXML: " .. tos(optionHighlightTemplates[entryType].template))
+--d(">entryType: " .. tos(entryType) ..", customHighlightXML: " .. tos(optionHighlightTemplates[entryType].template) .. "; templateWithCallback: " .. tos(optionHighlightTemplates[entryType].templateWithCallback))
 				--ZOs function overwrites exising table entries!
 				zo_mixin(XMLrowHighlightTemplatesToUse[entryType], optionHighlightTemplates[entryType])
 			end
@@ -3794,7 +3795,7 @@ function comboBox_base:GetHighLightTemplate(control, isSubMenu)
 			--Color the highlight light row green if the submenu has a callback (entry opening a submenu can be clicked to select it)
 			--but keep the color of the text as defined in options (self.XMLRowHighlightTemplates[entryType].color)
 			--Was a custom template provided in "templateWithCallback" for that case, then use it. Else use default template (green)
-			highlightTemplateData.template = highlightTemplateData.templateWithCallback or defaultHighlightTemplateDataEntryHavingSubMenuWithCallback.template
+			highlightTemplateData.template = (highlightTemplateData.templateWithCallback ~= nil and highlightTemplateData.templateWithCallback) or defaultHighlightTemplateDataEntryHavingSubMenuWithCallback.template
 		end
 	end
 	return highlightTemplateData
@@ -4516,7 +4517,7 @@ function comboBoxClass:UpdateOptions(options, onInit)
 
 	dLog(LSM_LOGTYPE_VERBOSE, "comboBoxClass:UpdateOptions - options: %s, onInit: %s, optionsChanged: %s", tos(options), tos(onInit), tos(optionsChanged))
 
-d("[LSM]comboBoxClass:UpdateOptions - options: " ..tos(options) .. ", onInit: " .. tos(onInit))
+--d("[LSM]comboBoxClass:UpdateOptions - options: " ..tos(options) .. ", onInit: " .. tos(onInit))
 
 	--Called from Initialization of the object -> self:ResetToDefaults() was called in comboBoxClass:Initialize() already
 	-->And self:UpdateOptions() is then called via comboBox_base.Initialize(...), from where we get here
@@ -4535,7 +4536,7 @@ d("[LSM]comboBoxClass:UpdateOptions - options: " ..tos(options) .. ", onInit: " 
 		optionsChanged = optionsChanged or options ~= self.options
 	end
 
-d("> optionsChanged: " .. tos(optionsChanged))
+--d("> optionsChanged: " .. tos(optionsChanged))
 
 	--(Did the options change: Yes / OR are we initializing a ZO_ComboBox ) / AND Are the new passed in options nil or empty: Yes
 	--> Reset to default ZO_ComboBox variables and just call AddCustomEntryTemplates()
@@ -4569,14 +4570,14 @@ d("> optionsChanged: " .. tos(optionsChanged))
 
 		-- LibScrollableMenu custom options
 		for key, _ in pairs(options) do
-d(">>setting option key: " ..tos(key))
+--d(">>setting option key: " ..tos(key))
 			self:SetOption(key)
 		end
 
 		--Reset the table with options which got updated
 		self.updatedOptions = nil
 
-d("> SetOption and for ... do SetOptions looped ")
+--d("> SetOption and for ... do SetOptions looped ")
 	end
 
 	-- this will add custom and default templates to self.XMLRowTemplates the same way dataTypes were created before.

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -2974,7 +2974,7 @@ function dropdownClass:OnShow(formattedEventName)
 	if formattedEventName ~= nil then
 		local anchorRight = self.anchorRight and 'Right' or 'Left'
 		local ctrl = self.control
-		lib:FireCallbacks(formattedEventName, ctrl)
+		lib:FireCallbacks(formattedEventName, ctrl, self)
 
 		throttledCall(function()
 			self:Narrate(formattedEventName, ctrl, nil, nil, anchorRight)
@@ -2988,7 +2988,7 @@ function dropdownClass:OnHide(formattedEventName)
 	if formattedEventName ~= nil then
 		local ctrl = self.control
 		self:Narrate(formattedEventName, ctrl)
-		lib:FireCallbacks(formattedEventName, ctrl)
+		lib:FireCallbacks(formattedEventName, ctrl, self)
 	end
 end
 
@@ -5526,7 +5526,7 @@ WORKING ON - Current version: 2.33 - Updated 2024-12-15
 	4. Contextmenu API functions return the index/indices of added entry/entries and boolean values (where applicable)
 	5. Changed XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
 	6. Fixed XMLRowTemplates using a non capital R at some locations
-
+	7. Handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
 
 -------------------
 TODO - To check (future versions)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -2590,7 +2590,7 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	-->>!!! ZO_ScrollList_EnableHighlight(self.scrollControl, function(control) end) cannot be used here as it does NOT overwrite existing highlightTemplateOrFunction !!!
 	local selfVar = self
 	self.scrollControl.highlightTemplateOrFunction = function(control)
-d("[LSM]highlightTemplateOrFunction - control: " .. tos(getControlName(control)) .. ", owner: " .. tos(selfVar.owner))
+--d("[LSM]highlightTemplateOrFunction - control: " .. tos(getControlName(control)) .. ", owner: " .. tos(selfVar.owner))
 		if selfVar.owner then
 			return selfVar.owner:GetHighlightTemplate(control)
 		end
@@ -3787,15 +3787,6 @@ function comboBox_base:GetHighLightTemplate(control, isSubMenu)
 	if not entryType then return end
 	local highlightTemplateData = self.XMLRowHighlightTemplates[entryType]
 
---todo for debugging 20241215 because somehow the normal row templates get replaced and all text is realy small???
---todo not only the highlight is changed
-	--[[
-	highlightTemplateData = {
-		template = defaultHighlightTemplate,
-		color = defaultHighlightColor,
-	}
-	]]
-
 	if isSubMenu and control.closeOnSelect then
 		local options = self:GetOptions()
 		if options and not options.useDefaultHighlightForSubmenuWithCallback then
@@ -3809,7 +3800,7 @@ end
 
 function comboBox_base:UpdateHighlightTemplate(control, isSubMenu)
 	local highlightTemplateData = self:GetHighLightTemplate(control, isSubMenu)
-d("[LSM]UpdateHighlightTemplate - name: " .. tos(getControlName(control)) .. ", entryType: " .. tos(control.typeId) .. "; HL_Template: " .. tos(highlightTemplateData.template) .. "; color: " .. tos(highlightTemplateData.color))
+--d("[LSM]UpdateHighlightTemplate - name: " .. tos(getControlName(control)) .. ", entryType: " .. tos(control.typeId) .. "; HL_Template: " .. tos(highlightTemplateData.template) .. "; color: " .. tos(highlightTemplateData.color))
 
 	if not highlightTemplateData then
 		control.m_data.m_highlightTemplate = nil
@@ -4209,8 +4200,6 @@ do -- Row setup functions
 		self:SetupEntryLabel(control, data, list)
 		control.isHeader = true
 		control.typeId = LSM_ENTRY_TYPE_HEADER
-
-		--self:UpdateHighlightTemplate(control, nil)
 	end
 
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1953,7 +1953,7 @@ local function addItem_Base(self, itemEntry)
 
 	if not itemEntry.customEntryTemplate then
 		--Set it's XML entry row template
-		setItemEntryCustomTemplate(itemEntry, self.XMLrowTemplates)
+		setItemEntryCustomTemplate(itemEntry, self.XMLRowTemplates)
 
 		--dLog(LSM_LOGTYPE_DEBUG, ">name: " .. tos(itemEntry.name) .. ", isHeader: " ..tos(itemEntry.isHeader))
 	end

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -33,10 +33,11 @@ local trem = table.remove
 lib.Debug = {}
 lib.Debug.doDebug = false
 lib.Debug.doVerboseDebug = false
-local libDebug = lib.Debug
 
+lib.Debug.prefix = debugPrefix
 local debugPrefix = "[" .. MAJOR .. "]"
-libDebug.prefix = debugPrefix
+
+local libDebug = lib.Debug
 
 
 local function initDebugLogging()
@@ -82,7 +83,7 @@ lib.SV = {} --will be init properly at the onAddonLoaded function
 local sv = lib.SV
 
 local function updateSavedVariable(svOptionName, newValue, subTableName)
---d("[LSM]updateSavedVariable - svOptionName: " ..tostring(svOptionName) .. ", newValue: " ..tostring(newValue) ..", subTableName: " ..tostring(subTableName))
+--d(debugPrefix .. "updateSavedVariable - svOptionName: " ..tostring(svOptionName) .. ", newValue: " ..tostring(newValue) ..", subTableName: " ..tostring(subTableName))
 	if svOptionName == nil then return end
 	local svOptionData = lib.SV[svOptionName]
 	if svOptionData == nil then return end
@@ -660,7 +661,7 @@ local function highlightControl(self, control)
 	
 	local highlightTemplate, animationFieldName = self:GetHighlightTemplate(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 1, tos(highlightTemplate)) end
---d("[LSM]highlightControl - highlightTemplate: " ..tos(highlightTemplate))
+--d(debugPrefix .. "highlightControl - highlightTemplate: " ..tos(highlightTemplate))
 
 	control.breadcrumbName = sfor('%s_%s', animationFieldName, self.breadcrumbName)
 	
@@ -1452,7 +1453,7 @@ local function updateIcon(control, data, iconIdx, singleIconDataOrTab, multiIcon
 		if isNewValue == true then
 			multiIconCtrl:AddIcon(iconNewIcon, nil, iconNarrationNewValue)
 			if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 25) end
-			--d("[LSM]updateIcon - Adding \'new icon\'")
+			--d(debugPrefix .. "updateIcon - Adding \'new icon\'")
 		end
 		if iconValue ~= nil then
 			--Icon's color
@@ -2573,7 +2574,7 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	-->>!!! ZO_ScrollList_EnableHighlight(self.scrollControl, function(control) end) cannot be used here as it does NOT overwrite existing highlightTemplateOrFunction !!!
 	local selfVar = self
 	self.scrollControl.highlightTemplateOrFunction = function(control)
---d("[LSM]highlightTemplateOrFunction - control: " .. tos(getControlName(control)) .. ", owner: " .. tos(selfVar.owner))
+--d(debugPrefix .. "highlightTemplateOrFunction - control: " .. tos(getControlName(control)) .. ", owner: " .. tos(selfVar.owner))
 		if selfVar.owner then
 			return selfVar.owner:GetHighlightTemplate(control)
 		end
@@ -3106,7 +3107,7 @@ function dropdownClass:ShowFilterEditBoxHistory(filterBox)
 	local comboBox = self.m_comboBox
 	if comboBox ~= nil then
 		local comboBoxContainerName = comboBox:GetUniqueName()
---d("[LSM]dropdownClass:ShowFilterEditBoxHistory - comboBoxContainerName: " .. tos(comboBoxContainerName))
+--d(debugPrefix .. "dropdownClass:ShowFilterEditBoxHistory - comboBoxContainerName: " .. tos(comboBoxContainerName))
 		if comboBoxContainerName == nil or comboBoxContainerName == "" then return end
 		--Get the last saved text search (history) and show them as context menu
 		local textSearchHistory = sv.textSearchHistory[comboBoxContainerName]
@@ -3139,7 +3140,7 @@ end
 --Called from XML at e.g. the collapsible header's editbox, and other controls
 --Used for event handlers like OnMouseUp and OnChanged etc.
 function lib.OnXMLControlEventHandler(owningWindowFunctionName, refVar, ...)
-	--d("[LSM]lib.OnXMLControlEventHandler - owningWindowFunctionName: " .. tos(owningWindowFunctionName))
+	--d(debugPrefix .. "lib.OnXMLControlEventHandler - owningWindowFunctionName: " .. tos(owningWindowFunctionName))
 
 	if refVar == nil or owningWindowFunctionName == nil then return end
 
@@ -3164,7 +3165,7 @@ function dropdownClass:OnFilterEditBoxMouseUp(filterBox, button, upInside)
 end
 
 function dropdownClass:ResetFilters(owningWindow)
---d("[LSM]dropdownClass:ResetFilters")
+--d(debugPrefix .. "dropdownClass:ResetFilters")
 	--If not showing the filters at a contextmenu
 	-->Close any opened contextmenu
 	if self.m_comboBox ~= nil and self.m_comboBox.openingControl == nil then
@@ -3178,7 +3179,7 @@ function dropdownClass:ResetFilters(owningWindow)
 end
 
 function dropdownClass:IsFilterEnabled()
---d("[LSM]dropdownClass:IsFilterEnabled")
+--d(debugPrefix .. "dropdownClass:IsFilterEnabled")
 	if self.m_comboBox then
 		return self.m_comboBox:IsFilterEnabled()
 	end
@@ -3558,7 +3559,7 @@ function comboBox_base:AddCustomEntryTemplates(options)
 
 	--Check if all XML row templates are passed in, and update missing ones with default values
 	if optionTemplates ~= nil then
---d("[LSM]options.XMLRowTemplates found!")
+--d(debugPrefix .. "options.XMLRowTemplates found!")
 		for entryType, _ in pairs(defaultXMLTemplates) do
 			if optionTemplates[entryType] ~= nil then
 				--ZOs function overwrites exising table entries!
@@ -3581,7 +3582,7 @@ function comboBox_base:AddCustomEntryTemplates(options)
 	--Check if all XML row highlight templates are passed in, and update missing ones with default values
 	--or set the template/color that should be used for all of the entryTypes
 	if optionHighlightTemplates or customHighlightTemplateForAllEntryTypes or customHighlightColorForAllEntryTypes then
---d("[LSM]customHighlightTemplateForAll: " .. tos(customHighlightTemplateForAllEntryTypes) ..", customHighlightColorForAll: ".. tos(customHighlightColorForAllEntryTypes) ..", optionHighlightTemplates: " .. tos(options.XMLRowHighlightTemplates))
+--d(debugPrefix .. "customHighlightTemplateForAll: " .. tos(customHighlightTemplateForAllEntryTypes) ..", customHighlightColorForAll: ".. tos(customHighlightColorForAllEntryTypes) ..", optionHighlightTemplates: " .. tos(options.XMLRowHighlightTemplates))
 		for entryType, _ in pairs(defaultXMLHighlightTemplates) do
 			if customHighlightTemplateForAllEntryTypes ~= nil then
 				XMLrowHighlightTemplatesToUse[entryType].template = customHighlightTemplateForAllEntryTypes
@@ -3767,7 +3768,7 @@ end
 
 --Get the current row's highlight template based on the options
 function comboBox_base:GetHighLightTemplate(control, isSubMenu)
-d("[LSM]comboBox_base:GetHighLightTemplate - control: " .. tos(getControlName(control)))
+d(debugPrefix .. "comboBox_base:GetHighLightTemplate - control: " .. tos(getControlName(control)))
 	--Get the highlight template based on the entryType
 	local entryType = control.typeId
 	if not entryType then return end
@@ -3787,7 +3788,7 @@ end
 
 function comboBox_base:UpdateHighlightTemplate(control, isSubMenu)
 	local highlightTemplateData = self:GetHighLightTemplate(control, isSubMenu)
---d("[LSM]UpdateHighlightTemplate - name: " .. tos(getControlName(control)) .. ", entryType: " .. tos(control.typeId) .. "; HL_Template: " .. tos(highlightTemplateData.template) .. "; color: " .. tos(highlightTemplateData.color))
+--d(debugPrefix .. "UpdateHighlightTemplate - name: " .. tos(getControlName(control)) .. ", entryType: " .. tos(control.typeId) .. "; HL_Template: " .. tos(highlightTemplateData.template) .. "; color: " .. tos(highlightTemplateData.color))
 
 	if not highlightTemplateData then
 		control.m_data.m_highlightTemplate = nil
@@ -3979,7 +3980,7 @@ function comboBox_base:UpdateItems()
 end
 
 function comboBox_base:UpdateHeight(control)
---d("[LSM]comboBox_base:UpdateHeight - control: " .. getControlName(control))
+--d(debugPrefix .. "comboBox_base:UpdateHeight - control: " .. getControlName(control))
 	local maxHeightInTotal = 0
 
 	local spacing = self.m_spacing or 0
@@ -4176,7 +4177,7 @@ do -- Row setup functions
 		addArrow(control, data, list)
 		control.typeId = LSM_ENTRY_TYPE_SUBMENU
 
---d("[LSM]submenu setup: - name: " .. tos(getValueOrCallback(data.label or data.name, data)) ..", closeOnSelect: " ..tos(control.closeOnSelect) .. "; m_highlightTemplate: " ..tos(data.m_highlightTemplate) )
+--d(debugPrefix .. "submenu setup: - name: " .. tos(getValueOrCallback(data.label or data.name, data)) ..", closeOnSelect: " ..tos(control.closeOnSelect) .. "; m_highlightTemplate: " ..tos(data.m_highlightTemplate) )
 
 		self:UpdateHighlightTemplate(control, true)
 	end
@@ -4422,7 +4423,7 @@ end
 function comboBoxClass:IsFilterEnabled()
 	local options = self:GetOptions()
 	local enableFilter = (options and getValueOrCallback(options.enableFilter, options)) or false
---d("[LSM]comboBoxClass:IsFilterEnabled - enableFilter: " ..tos(enableFilter))
+--d(debugPrefix .. "comboBoxClass:IsFilterEnabled - enableFilter: " ..tos(enableFilter))
 	if not enableFilter then
 		self.filterString = ""
 	else
@@ -4503,7 +4504,7 @@ function comboBoxClass:UpdateOptions(options, onInit)
 
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 136, tos(options), tos(onInit), tos(optionsChanged)) end
 
---d("[LSM]comboBoxClass:UpdateOptions - options: " ..tos(options) .. ", onInit: " .. tos(onInit))
+--d(debugPrefix .. "comboBoxClass:UpdateOptions - options: " ..tos(options) .. ", onInit: " .. tos(onInit))
 
 	--Called from Initialization of the object -> self:ResetToDefaults() was called in comboBoxClass:Initialize() already
 	-->And self:UpdateOptions() is then called via comboBox_base.Initialize(...), from where we get here
@@ -4781,7 +4782,7 @@ function submenuClass:ShouldHideDropdown()
 end
 
 function submenuClass:IsMouseOverOpeningControl()
---d("[LSM]submenuClass:IsMouseOverOpeningControl: " .. tos(MouseIsOver(self.openingControl)))
+--d(debugPrefix .. "submenuClass:IsMouseOverOpeningControl: " .. tos(MouseIsOver(self.openingControl)))
 	return MouseIsOver(self.openingControl)
 end
 
@@ -4837,7 +4838,7 @@ function contextMenuClass:AddMenuItems(parentControl, comingFromFilters)
 end
 
 function contextMenuClass:ClearItems()
-d(debugPrefix .. 'contextMenuClass:ClearItems()')
+--d(debugPrefix .. 'contextMenuClass:ClearItems()')
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 152) end
 	self:SetContextMenuOptions(nil)
 	self:ResetToDefaults()
@@ -4883,7 +4884,7 @@ end
 function contextMenuClass:ShowContextMenu(parentControl)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 157, tos(getControlName(parentControl))) end
 
---d("[LSM]->->->->-> contextMenuClass:ShowContextMenu")
+--d(debugPrefix .. "->->->->-> contextMenuClass:ShowContextMenu")
 	--Cache last opening Control for the comparison with new openingControl and reset of filters etc. below
 	local openingControlOld = self.openingControl
 	self.openingControl = parentControl
@@ -4902,7 +4903,7 @@ function contextMenuClass:ShowContextMenu(parentControl)
 	self:UpdateOptions(self.contextMenuOptions)
 
 
---d("[LSM]ctxMen-contextMenuOptions.highlightContextMenuOpeningControl: " ..tos(self.contextMenuOptions.highlightContextMenuOpeningControl))
+--d(debugPrefix .. "ctxMen-contextMenuOptions.highlightContextMenuOpeningControl: " ..tos(self.contextMenuOptions.highlightContextMenuOpeningControl))
 	if self.openingControl then
 		--Options tell us to highlight the openingControl?
 		if self.contextMenuOptions.highlightContextMenuOpeningControl then
@@ -4913,10 +4914,10 @@ function contextMenuClass:ShowContextMenu(parentControl)
 --d("->->->->->->-> [LSM]ContextMenuClass:ShowContextMenu -> ShowDropdown now!")
 	self:ShowDropdown()
 
---d("[LSM]ContextMenuClass:ShowContextMenu - openingControl changed!")
+--d(debugPrefix .. "ContextMenuClass:ShowContextMenu - openingControl changed!")
 	throttledCall(function()
 		if openingControlOld ~= parentControl then
---d("[LSM]ContextMenuClass:ShowContextMenu - openingControl changed!")
+--d(debugPrefix .. "ContextMenuClass:ShowContextMenu - openingControl changed!")
 			if self:IsFilterEnabled() then
 	--d(">>resetting filters now")
 				local dropdown = self.m_dropdown
@@ -4933,7 +4934,7 @@ function contextMenuClass:SetContextMenuOptions(options)
 	-- so we can check here if anything changed within the passed in options paramter (compared to previous options)
 	self.optionsChanged = self.contextMenuOptions ~= options
 
-	--d("[LSM]contextMenuClass:SetContextMenuOptions - optionsChanged: " .. tos(self.optionsChanged))
+	--d(debugPrefix .. "contextMenuClass:SetContextMenuOptions - optionsChanged: " .. tos(self.optionsChanged))
 	--Wil be used in contextMenuClass:ShowContextMenu -> self:UpdateOptions(self.contextMenuOptions)
 	self.contextMenuOptions = options
 end
@@ -5258,7 +5259,7 @@ local setCustomScrollableMenuOptions = SetCustomScrollableMenuOptions
 
 --Hide the custom scrollable context menu and clear it's entries, clear internal variables, mouse clicks etc.
 function ClearCustomScrollableMenu()
---d("[LSM]<<<<<< ClearCustomScrollableMenu <<<<<<<<<<<<<")
+--d(debugPrefix .. "<<<<<< ClearCustomScrollableMenu <<<<<<<<<<<<<")
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 168) end
 	hideContextMenu()
 
@@ -5398,7 +5399,7 @@ function RunCustomScrollableMenuItemsCallback(comboBox, item, myAddonCallbackFun
 		assert(type(fromParentMenuValue) == "boolean", sfor('['..MAJOR..':'..assertFuncName..'] fromParentMenu: boolean expected, got %q', tos(type(fromParentMenu))))
 	end
 
---d("[LSM]"..assertFuncName.." - filterEntryTypes: " ..tos(gotFilterEntryTypes) .. ", type: " ..tos(filterEntryTypesTableType) ..", fromParentMenu: " ..tos(fromParentMenuValue))
+--d(debugPrefix .. ""..assertFuncName.." - filterEntryTypes: " ..tos(gotFilterEntryTypes) .. ", type: " ..tos(filterEntryTypesTableType) ..", fromParentMenu: " ..tos(fromParentMenuValue))
 
 	--Find out via comboBox and item -> What was the "opening menu" and "how do I get openingMenu m_sortedItems"?
 	--comboBox would be the comboBox or dropdown of the context menu -> if RunCustomScrollableMenuCheckboxCallback was called from the callback of a contex menu entry
@@ -5446,7 +5447,7 @@ local function buttonGroupDefaultContextMenu(comboBox, control, data)
 	local entryType = getValueOrCallback(data.entryType, data)
 	if entryType == nil then return end
 
---d("[LSM]setButtonGroupState - comboBox: " .. tos(comboBox) .. ", control: " .. tos(getControlName(control)) .. ", entryType: " .. tos(entryType) .. ", groupIndex: " .. tos(groupIndex))
+--d(debugPrefix .. "setButtonGroupState - comboBox: " .. tos(comboBox) .. ", control: " .. tos(getControlName(control)) .. ", entryType: " .. tos(entryType) .. ", groupIndex: " .. tos(groupIndex))
 
 	local buttonGroupSetAll = {
 		{ -- LSM_ENTRY_TYPE_NORMAL selecct and close.
@@ -5490,7 +5491,7 @@ local function buttonGroupDefaultContextMenu(comboBox, control, data)
 
 	clearCustomScrollableMenu()
 	addCustomScrollableMenuEntries(buttonGroupSetAll)
---d("[LSM]°°°°°°°°°°°°°°°° showCustomScrollableMenu checkbox context menu")
+--d(debugPrefix .. "°°°°°°°°°°°°°°°° showCustomScrollableMenu checkbox context menu")
 	showCustomScrollableMenu(nil, nil)
 end
 lib.SetButtonGroupState = buttonGroupDefaultContextMenu --Only for compatibilitxy (if any other addon was using 'SetButtonGroupState' already)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1591,6 +1591,11 @@ local function getComboBox(control, owningMenu)
 	end
 end
 
+local function fireOnDropownMenuAddedCallback(selfVar, options)
+d("[LSM]FireCallbacks - OnDropdownMenuAdded - current visibleRows: " ..tostring(options.visibleRowsDropdown))
+	lib:FireCallbacks('OnDropdownMenuAdded', selfVar, options)
+	dLog(LSM_LOGTYPE_DEBUG_CALLBACK, "FireCallbacks: OnDropdownMenuAdded - control: %s, options: %s", tos(getControlName(selfVar.m_container)), tos(options))
+end
 
 ------------------------------------------------------------------------------------------------------------------------
 --Local context menu helper functions
@@ -4609,12 +4614,14 @@ end
 function comboBoxClass:UpdateMetatable(parent, comboBoxContainer, options)
 	dLog(LSM_LOGTYPE_VERBOSE, "comboBoxClass:UpdateMetatable - parent: %s, comboBoxContainer: %s, options: %s", tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(options))
 
+--d("comboBoxClass:UpdateMetatable")
+
 	setmetatable(self, comboBoxClass)
 	ApplyTemplateToControl(comboBoxContainer, 'LibScrollableMenu_ComboBox_Behavior')
 
---d("[LSM]FireCallbacks - OnDropdownMenuAdded - current visibleRows: " ..tostring(options.visibleRowsDropdown))
-	lib:FireCallbacks('OnDropdownMenuAdded', self, options)
-	dLog(LSM_LOGTYPE_DEBUG_CALLBACK, "FireCallbacks: OnDropdownMenuAdded - control: %s, options: %s", tos(getControlName(self.m_container)), tos(options))
+	--Fire the OnDropdownMenuAdded callback where one can replace options in the options table
+	fireOnDropownMenuAddedCallback(self, options)
+
 	self:Initialize(parent, comboBoxContainer, options, 1, true)
 end
 
@@ -5056,7 +5063,7 @@ function AddCustomScrollableComboBoxDropdownMenu(parent, comboBoxContainer, opti
 	assert(comboBox and comboBox.IsInstanceOf and comboBox:IsInstanceOf(ZO_ComboBox), MAJOR .. ' | The comboBoxContainer you supplied must be a valid ZO_ComboBox container. "comboBoxContainer.m_comboBox:IsInstanceOf(ZO_ComboBox)"')
 
 	dLog(LSM_LOGTYPE_DEBUG, "AddCustomScrollableComboBoxDropdownMenu - parent: %s, comboBoxContainer: %s, options: %s", tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(options))
-	comboBoxClass.UpdateMetatable(comboBox, parent, comboBoxContainer, options)
+	comboBoxClass.UpdateMetatable(comboBox, parent, comboBoxContainer, options) --Calls comboboxCLass:Initialize
 
 	return comboBox.m_dropdownObject
 end
@@ -5332,6 +5339,9 @@ end
 function ShowCustomScrollableMenu(controlToAnchorTo, options)
 	dLog(LSM_LOGTYPE_DEBUG, "ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
 --df("_-_-_-_-_-_-_-_-_-_ [LSM]ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
+
+	--Fire the OnDropdownMenuAdded callback where one can replace options in the options table -> Here: For the contextMenu
+	fireOnDropownMenuAddedCallback(g_contextMenu, options)
 
 	if options then
 		setCustomScrollableMenuOptions(options)
@@ -5643,7 +5653,7 @@ LibScrollableMenu = lib
 
 --[[
 -------------------
-WORKING ON - Current version: 2.33 - Updated 2024-12-15
+WORKING ON - Current version: 2.33 - Updated 2024-12-16
 -------------------
 	1. Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 	2. Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
@@ -5653,6 +5663,7 @@ WORKING ON - Current version: 2.33 - Updated 2024-12-15
 	6. Fixed XMLRowTemplates using a non capital R at some locations
 	7. Handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
 	8. Added options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType
+	9. Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
 
 -------------------
 TODO - To check (future versions)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -13,14 +13,55 @@ lib.version = "2.33"
 
 if not lib then return end
 
---For debugging and logging
+--------------------------------------------------------------------
+-- Locals
+--------------------------------------------------------------------
+--ZOs local speed-up/reference variables
+local EM = EVENT_MANAGER
+local SNM = SCREEN_NARRATION_MANAGER
+local tos = tostring
+local sfor = string.format
+local zostrlow = zo_strlower
+local tins = table.insert
+local trem = table.remove
+
+
+--------------------------------------------------------------------
+-- For debugging and logging
+--------------------------------------------------------------------
 --Logging and debugging
 lib.Debug = {}
 lib.Debug.doDebug = false
 lib.Debug.doVerboseDebug = false
 local libDebug = lib.Debug
 
+local function initDebugLogging()
+	if not lib.Debug then return false end
+	libDebug = lib.Debug
+	if not libDebug.LoadLogger then return false end
+	libDebug.LoadLogger()
+	return true
+end
 local dlog --= libDebug.DebugLog, updated at EVENT_ADDON_LOADED
+
+local function debugLoggingToggle(debugType)
+	if not initDebugLogging() then return end
+
+	if debugType == "debug" then
+		lib.Debug.doDebug = not lib.Debug.doDebug
+		libDebug = lib.Debug
+		if libDebug.logger then libDebug.logger:SetEnabled(libDebug.doDebug) end
+		if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 176, tos(libDebug.doDebug and "ON" or "OFF")) end
+
+	elseif debugType == "debugVerbose" then
+		lib.Debug.doVerboseDebug = not lib.Debug.doVerboseDebug
+		libDebug = lib.Debug
+		if libDebug.logger and libDebug.logger.verbose then
+			libDebug.logger.verbose:SetEnabled(libDebug.doVerboseDebug)
+			if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 177, tos(libDebug.doVerboseDebug and "ON" or "OFF"), tos(libDebug.doDebug and "ON" or "OFF")) end
+		end
+	end
+end
 
 
 --------------------------------------------------------------------
@@ -68,18 +109,6 @@ end
 --------------------------------------------------------------------
 -- Libraries
 --------------------------------------------------------------------
-
---------------------------------------------------------------------
--- Locals
---------------------------------------------------------------------
---ZOs local speed-up/reference variables
-local EM = EVENT_MANAGER
-local SNM = SCREEN_NARRATION_MANAGER
-local tos = tostring
-local sfor = string.format
-local zostrlow = zo_strlower
-local tins = table.insert
-local trem = table.remove
 
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -5552,20 +5581,10 @@ local function onAddonLoaded(event, name)
 	--Slash commands
 	--------------------------------------------------------------------------------------------------------------------
 	SLASH_COMMANDS["/lsmdebug"] = function()
-		libDebug.LoadLogger()
-		libDebug = lib.Debug
-		libDebug.doDebug = not libDebug.doDebug
-		if libDebug.logger then libDebug.logger:SetEnabled(libDebug.doDebug) end
-		if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 176, tos(libDebug.doDebug and "ON" or "OFF")) end
+		debugLoggingToggle("debug")
 	end
 	SLASH_COMMANDS["/lsmdebugverbose"] = function()
-		libDebug.LoadLogger()
-		libDebug = lib.Debug
-		lib.doVerboseDebug = not lib.doVerboseDebug
-		if libDebug.logger and libDebug.logger.verbose then
-			libDebug.logger.verbose:SetEnabled(lib.doVerboseDebug)
-			if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 177, tos(lib.doVerboseDebug and "ON" or "OFF"), tos(libDebug.doDebug and "ON" or "OFF")) end
-		end
+		debugLoggingToggle("debugVerbose")
 	end
 end
 EM:UnregisterForEvent(MAJOR, EVENT_ADD_ON_LOADED)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -421,7 +421,7 @@ lib.LSMOptionsToZO_ComboBoxOptionsCallbacks = LSMOptionsToZO_ComboBoxOptionsCall
 --Submenu key mapping
 
 -- Pass-through variables:
---If submenuClass_exposedVariables[key] == true: if submenu[key] is nil, returns submenu.m_comboBox[key]
+--If submenuClass_exposedVariables[key] == true: if submenu[key] is nil, returns submenu.m_comboBox[key] (means it takes the value from the owning LSM dropdown for the submenu then)
 --> where key = e.g. "m_font"
 local submenuClass_exposedVariables = {
 	-- ZO_ComboBox
@@ -460,7 +460,7 @@ local submenuClass_exposedVariables = {
 	['options'] = true,
 	['narrateData'] = true,
 	['m_headerFont'] = true,
-	['XMLrowTemplates'] = true, --TODO: is this being overwritten?
+	['XMLRowTemplates'] = true, --TODO: is this being overwritten?
 	['maxDropdownHeight'] = true,
 	['m_headerFontColor'] = true,
 	['m_highlightTemplate'] = true,
@@ -3519,10 +3519,10 @@ function comboBox_base:AddCustomEntryTemplates(options)
 			end
 		end
 	end
+	self.XMLRowTemplates = XMLrowTemplatesToUse
 
 	--Set the row templates to use to the current object
 	--[[ for debugging
-		self.XMLrowTemplates = XMLrowTemplatesToUse
 		lib._debugXMLrowTemplates = lib._debugXMLrowTemplates or {}
 		lib._debugXMLrowTemplates[self] = self
 	]]
@@ -4473,7 +4473,7 @@ function comboBoxClass:UpdateOptions(options, onInit)
 		self.updatedOptions = nil
 	end
 
-	-- this will add custom and default templates to self.XMLrowTemplates the same way dataTypes were created before.
+	-- this will add custom and default templates to self.XMLRowTemplates the same way dataTypes were created before.
 	self:AddCustomEntryTemplates(options)
 end
 
@@ -5533,6 +5533,7 @@ WORKING ON - Current version: 2.33 - Updated 2024-12-15
 	3. Renamed API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
 	4. Contextmenu API functions return the index/indices of added entry/entries and boolean values (where applicable)
 	5. Changed XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
+	6. Fixed XMLRowTemplates using a non capital R at some locations
 
 
 -------------------

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -17,6 +17,7 @@ lang/en.lua
 lang/$(language).lua
 
 LibScrollableMenu.lua
+debug.lua
 LibScrollableMenu.xml
 
 ## Uncomment this to test the combobox with different menu entryTypes and submenus

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,11 +5,11 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.32
-## AddOnVersion: 020302
+## Version: 2.33
+## AddOnVersion: 020303
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
-## APIVersion: 101043 101044
+## APIVersion: 101044 101045
 ## OptionalDependsOn: LibDebugLogger>=263
 ## SavedVariables: LibScrollableMenu_SavedVars
 

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -23,4 +23,4 @@ LibScrollableMenu.xml
 ## Uncomment this to test the combobox with different menu entryTypes and submenus
 ## Use slash command /lsmtest to show the test UI
 ## Inspect the code in LSM_test.lua file to see how the API functions etc. work
-LSM_test.lua
+## LSM_test.lua

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -23,4 +23,4 @@ LibScrollableMenu.xml
 ## Uncomment this to test the combobox with different menu entryTypes and submenus
 ## Use slash command /lsmtest to show the test UI
 ## Inspect the code in LSM_test.lua file to see how the API functions etc. work
-## LSM_test.lua
+LSM_test.lua

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -138,7 +138,7 @@
 				<Button name="$(parent)Checkbox" inherits="ZO_CheckButton" level="3">
 					<OnInitialized>
 						<!-- We propogate the row OnMouseUp to the button's OnClicked so clicking the row simulates clicking the button -->
-						LibScrollableMenu.ButtonOnInitialize(self)
+						LibScrollableMenu.XMLButtonOnInitialize(self, LSM_ENTRY_TYPE_CHECKBOX)
 					</OnInitialized>
 
 					<OnMouseEnter name="ZO_PropagateMouseOverBehavior">
@@ -173,7 +173,7 @@
 				<Button name="$(parent)RadioButton" inherits="ZO_RadioButton" level="3">
 					<OnInitialized>
 						<!-- We propogate the row OnMouseUp to the button's OnClicked so clicking the row simulates clicking the button -->
-						LibScrollableMenu.ButtonOnInitialize(self, true)
+						LibScrollableMenu.XMLButtonOnInitialize(self, LSM_ENTRY_TYPE_RADIOBUTTON)
 					</OnInitialized>
 
 					<OnMouseEnter name="ZO_PropagateMouseOverBehavior">

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -237,27 +237,31 @@
 		<TopLevelControl name="LibScrollableMenu_Dropdown_Behavior" virtual="true">
 			<OnEffectivelyHidden name="HideDropDown" >
 				<!-- Handler set normally in ZO_ComboBox:Initialize -->
-				if self.object then
-					self.object:HideDropdown()
+				local dropdownObject = self.object
+				if dropdownObject then
+					dropdownObject:XMLHandler(self, "OnEffectivelyHidden")
 				end
 			</OnEffectivelyHidden>
 	
 			<OnMouseEnter name="CloseCheck">
 				-- Do we need to close any submenus on dropdown enter?
-				if self.object then
-					self.object:OnMouseExitTimeout(self)
+				local dropdownObject = self.object
+				if dropdownObject then
+					dropdownObject:XMLHandler(self, "OnMouseEnter")
 				end
 			</OnMouseEnter>
 			
 			<OnShow name="Narrate">
-				if self.object then
-					self.object:OnShow(self.object:GetFormattedNarrateEvent('Show'))
+				local dropdownObject = self.object
+				if dropdownObject then
+					dropdownObject:XMLHandler(self, "OnShow") --calls dropdownObject:GetFormattedNarrateEvent
 				end
 			</OnShow>
 			
 			<OnHide name="Narrate">
-				if self.object then
-					self.object:OnHide(self.object:GetFormattedNarrateEvent('Hide'))
+				local dropdownObject = self.object
+				if dropdownObject then
+					dropdownObject:XMLHandler(self, "OnHide") --calls dropdownObject:GetFormattedNarrateEvent
 				end
 			</OnHide>
 		</TopLevelControl>

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -394,7 +394,6 @@
 									<Controls>
 										<EditBox name="$(parent)Box" excludeFromResizeToFitExtents="true" inherits="ZO_DefaultEditForBackdrop" defaultText="SI_SEARCH_FILTER_BY">
 											<OnTextChanged>
-												LibScrollableMenu.checkIfZO_MenuReplacementByLSMWasHookedAndPreventClearCustomScrollableMenuCall()
 												ClearMenu()
 												LibScrollableMenu.OnXMLControlEventHandler("SetFilterString", self, self)
 											</OnTextChanged>

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -365,10 +365,7 @@
 									/>
 
 									<OnMouseEnter>
-										local owningWindow = self:GetOwningWindow()
-										if owningWindow.object then
-											owningWindow.object:ShowTextTooltip(self, BOTTOM, GetString(SI_HOOK_POINT_STORE_RESET), owningWindow)
-										end
+										LibScrollableMenu.OnXMLControlEventHandler("ShowTextTooltip", self, self, BOTTOM, GetString(SI_HOOK_POINT_STORE_RESET), nil)
 									</OnMouseEnter>
 
 									<OnMouseExit>
@@ -376,11 +373,7 @@
 									</OnMouseExit>
 									
 									<OnClicked>
-										ZO_Tooltips_HideTextTooltip()
-										local owningWindow = self:GetOwningWindow()
-										if owningWindow.object then
-											owningWindow.object:ResetFilters(owningWindow)
-										end
+										LibScrollableMenu.OnXMLControlEventHandler("ResetFilters", self, self:GetOwningWindow())
 									</OnClicked>
 								</Button>
 								
@@ -401,19 +394,13 @@
 									<Controls>
 										<EditBox name="$(parent)Box" excludeFromResizeToFitExtents="true" inherits="ZO_DefaultEditForBackdrop" defaultText="SI_SEARCH_FILTER_BY">
 											<OnTextChanged>
-												ZO_Tooltips_HideTextTooltip()
+												LibScrollableMenu.checkIfZO_MenuReplacementByLSMWasHookedAndPreventClearCustomScrollableMenuCall()
 												ClearMenu()
-												local owningWindow = self:GetOwningWindow()
-												if owningWindow.object then
-													owningWindow.object:SetFilterString(self)
-												end
+												LibScrollableMenu.OnXMLControlEventHandler("SetFilterString", self, self)
 											</OnTextChanged>
 
 											<OnMouseEnter>
-												local owningWindow = self:GetOwningWindow()
-												if owningWindow.object then
-													owningWindow.object:ShowTextTooltip(self, BOTTOM, GetString(SI_LSM_SEARCH_FILTER_TOOLTIP), owningWindow)
-												end
+												LibScrollableMenu.OnXMLControlEventHandler("ShowTextTooltip", self, self, BOTTOM, GetString(SI_LSM_SEARCH_FILTER_TOOLTIP), nil)
 											</OnMouseEnter>
 
 											<OnMouseExit>
@@ -421,12 +408,7 @@
 											</OnMouseExit>
 
 											<OnMouseUp>
-												ZO_Tooltips_HideTextTooltip()
-												ClearMenu()
-												local owningWindow = self:GetOwningWindow()
-												if owningWindow.object then
-													owningWindow.object:OnFilterEditBoxMouseUp(self, button, upInside)
-												end
+												LibScrollableMenu.OnXMLControlEventHandler("OnFilterEditBoxMouseUp", self, self, button, upInside)
 											</OnMouseUp>
 										</EditBox>
 									</Controls>
@@ -553,10 +535,7 @@
 							/>
 
 							<OnMouseEnter>
-								local owningWindow = self:GetOwningWindow()
-								if owningWindow.object then
-									owningWindow.object:ShowTextTooltip(self, BOTTOM, self:GetTooltipText(), owningWindow)
-								end
+								LibScrollableMenu.OnXMLControlEventHandler("ShowTextTooltip", self, self, BOTTOM, self:GetTooltipText(), nil)
 							</OnMouseEnter>
 
 							<OnMouseExit>
@@ -579,9 +558,8 @@
 
 							<OnMouseEnter>
 								local owningWindow = self:GetOwningWindow()
-								if owningWindow.object then
-									local toggleButton = owningWindow.toggleButton
-									owningWindow.object:ShowTextTooltip(self, BOTTOM, toggleButton:GetTooltipText(), owningWindow)
+								if owningWindow then
+									LibScrollableMenu.OnXMLControlEventHandler("ShowTextTooltip", self, self, BOTTOM, owningWindow.toggleButton and owningWindow.toggleButton:GetTooltipText(), owningWindow)
 								end
 							</OnMouseEnter>
 

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -13,7 +13,7 @@
 		<Backdrop name="LibScrollableMenu_Highlight_Green" inherits="ZO_SelectionHighlight" virtual="true" blendMode="ADD" centerColor="00ff00" edgeColor="00ff00"/>
 		<Backdrop name="LibScrollableMenu_Highlight_Red" inherits="ZO_SelectionHighlight" virtual="true" blendMode="ADD" centerColor="ff0000" edgeColor="ff0000"/>
 		<Backdrop name="LibScrollableMenu_Highlight_Blue" inherits="ZO_SelectionHighlight" virtual="true" blendMode="ADD" centerColor="0000ff" edgeColor="0000ff"/>
-		<Backdrop name="LibScrollableMenu_Highlight_White" inherits="ZO_SelectionHighlight" virtual="true" blendMode="ADD" centerColor="ffffff" edgeColor="ffffff"/>
+		<Backdrop name="LibScrollableMenu_Highlight_Opaque" inherits="ZO_SelectionHighlight" virtual="true" blendMode="ADD" centerColor="0F0F0F" edgeColor="0F0F0F"/>
 
 		<!-- Divider | no icon no handlers -->
 		<Texture name="LibScrollableMenu_ComboBoxDividerEntry" inherits="ZO_BaseTooltipDivider" virtual="true">

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -80,8 +80,6 @@
 			<OnMouseUp>
 				local dropdown = self.m_dropdownObject
 				if dropdown then
-						--d("[LSM]dropdown.OnEntryMouseUp - button: " ..tostring(button) .. ", upInside: " .. tostring(upInside))
-						--LibScrollableMenu._debug = { self = self, button = button, upInside = upInside }
 					dropdown:OnEntryMouseUp(self, button, upInside)
 				end
 			</OnMouseUp>

--- a/LibScrollableMenu/LibScrollableMenu.xml
+++ b/LibScrollableMenu/LibScrollableMenu.xml
@@ -95,7 +95,7 @@
 			</OnInitialized>
 
 			<Controls>
-				<Label name="$(parent)Label" verticalAlignment="CENTER" font="ZoFontWinH5" color="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_CONTEXT_HIGHLIGHT" maxLineCount="1">
+				<Label name="$(parent)Label" verticalAlignment="CENTER" font="ZoFontWinH5" color="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_CONTEXT_HIGHLIGHT" maxLineCount="1">
 					<Anchor point="TOPLEFT" relativeTo="$(parent)IconContainer" relativePoint="TOPRIGHT" offsetX="0" />
 					<Anchor point="BOTTOMRIGHT" offsetX="ZO_COMBO_BOX_ENTRY_TEMPLATE_LABEL_PADDING" offsetY="-5"  />
 				</Label>

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,9 +1,16 @@
+-v- ---------------LSM v2.33 - 2024-12-15---------------------------------------------------------------------------- -v-
+-Added return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
+-Renamed API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
+-Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
+-Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
+-Changed XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
+
+
 -v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-
 -[Additions]-
 -Added attribute ".doNotFilter boolean" to all entryTypes. If true then do not hide those controls if a search/filter is used
   -> e.g. used for a button "Apply changes" at a submenu to apply checkboxes checked/unchecked state now even if search filter was hiding non-matching checkboxes
 -Changed collapsible header to expand if you click the whole header, and not only the small v^ button
-
 
 -v- ---------------LSM v2.31 - 2024-08-25---------------------------------------------------------------------------- -v-
 -[Fixes]-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,11 +1,13 @@
--v- ---------------LSM v2.33 - 2024-12-15---------------------------------------------------------------------------- -v-
--Added return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
--Renamed API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
+-v- ---------------LSM v2.33 - 2024-12-16---------------------------------------------------------------------------- -v-
 -Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 -Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
 -Bug fix: XMLRowTemplates using a non capital R at some locations
--Changed XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
--Handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
+-Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
+-Changed: XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
+-Changed: handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
+-Added: options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType
+-Added: return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
+-Renamed: API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
 
 
 -v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -3,7 +3,9 @@
 -Renamed API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
 -Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 -Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
+-Bug fix: XMLRowTemplates using a non capital R at some locations
 -Changed XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
+-Handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
 
 
 -v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -4,6 +4,7 @@
 -Bug fix: XMLRowTemplates using a non capital R at some locations
 -Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
 -Bug fix: options.headerFont and headerColor work now
+-Bug fix: Hide the tooltip as checkbox is toggled, or radioButton is changed
 -Changed: XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
 -Changed: handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
 -Changed: Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,13 +1,16 @@
--v- ---------------LSM v2.33 - 2024-12-16---------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.33 - 2024-12-21---------------------------------------------------------------------------- -v-
 -Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 -Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
 -Bug fix: XMLRowTemplates using a non capital R at some locations
 -Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
+-Bug fix: options.headerFont and headerColor work now
 -Changed: XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
 -Changed: handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
+-Changed: Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled
 -Added: options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType
 -Added: return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
 -Renamed: API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
+-Renamed: self.optionsData at contextMenus was properly renamed to self.contextMenuOptions
 
 
 -v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/debug.lua
+++ b/LibScrollableMenu/debug.lua
@@ -250,7 +250,7 @@ local function loadLogger()
 		lib.Debug.logger = logger
 	end
 end
-lib.LoadLogger = loadLogger
+libDebug.LoadLogger = loadLogger
 
 
 --Early try to load libs and to create logger (done again in EVENT_ADD_ON_LOADED)
@@ -303,4 +303,4 @@ local function dlog(debugType, textId, ...)
 		end
 	end
 end
-lib.DebugLog = dlog
+libDebug.DebugLog = dlog

--- a/LibScrollableMenu/debug.lua
+++ b/LibScrollableMenu/debug.lua
@@ -21,7 +21,7 @@ local sfor = string.format
 local libDebug = lib.Debug
 
 local logger
-local debugPrefix = "[" .. MAJOR .. "]"
+local debugPrefix = lib.Debug.prefix
 
 --DebugLog types
 local LSM_LOGTYPE_DEBUG = 1

--- a/LibScrollableMenu/debug.lua
+++ b/LibScrollableMenu/debug.lua
@@ -1,0 +1,306 @@
+local lib = LibScrollableMenu
+if not lib then return end
+
+local MAJOR = lib.name
+
+--------------------------------------------------------------------
+-- Libraries
+--------------------------------------------------------------------
+local LDL = LibDebugLogger
+
+
+--------------------------------------------------------------------
+-- Locals
+--------------------------------------------------------------------
+--ZOs local speed-up/reference variables
+local sfor = string.format
+
+
+------------------------------------------------------------------------------------------------------------------------
+--Logging and debugging
+local libDebug = lib.Debug
+
+local logger
+local debugPrefix = "[" .. MAJOR .. "]"
+
+--DebugLog types
+local LSM_LOGTYPE_DEBUG = 1
+local LSM_LOGTYPE_VERBOSE = 2
+local LSM_LOGTYPE_DEBUG_CALLBACK = 3
+local LSM_LOGTYPE_INFO = 10
+local LSM_LOGTYPE_ERROR = 99
+libDebug.LSM_LOGTYPE_DEBUG = LSM_LOGTYPE_DEBUG
+libDebug.LSM_LOGTYPE_VERBOSE = LSM_LOGTYPE_VERBOSE
+libDebug.LSM_LOGTYPE_DEBUG_CALLBACK = LSM_LOGTYPE_DEBUG_CALLBACK
+libDebug.LSM_LOGTYPE_INFO = LSM_LOGTYPE_INFO
+libDebug.LSM_LOGTYPE_ERROR = LSM_LOGTYPE_ERROR
+
+--DebugLog type to name mapping
+local loggerTypeToName = {
+	[LSM_LOGTYPE_DEBUG] = 			" -DEBUG- ",
+	[LSM_LOGTYPE_VERBOSE] = 		" -VERBOSE- ",
+	[LSM_LOGTYPE_DEBUG_CALLBACK] = 	" -CALLBACK- ",
+	[LSM_LOGTYPE_INFO] = 			" -INFO- ",
+	[LSM_LOGTYPE_ERROR] = 			" -ERROR- ",
+}
+
+
+--------------------------------------------------------------------
+-- Debug logging
+--------------------------------------------------------------------
+
+--The debug messages patterns with their uniqueId. The function dLog only passes in the textId and params to make it
+--more performant
+local debugLogMessagePatterns = {
+	[1]  = "highlightControl - highlightTemplate:  %s",
+	[2]  = "getDropdownTemplate - templateName:  %s",
+	[3]  = "getScrollContentsTemplate - barHidden:  %s",
+	[4]  = "REGISTERING throttledCall - callback: %s, delay: %s, name: %s",
+	[5]  = "DELAYED throttledCall -> CALLING callback now: %s, name: %s",
+	[6]  = "getValueOrCallback - arg:  %s",
+	[7]  = "ClearTimeout",
+	[8]  = "setTimeout",
+	[9]  = "setTimeout -> delayed by:  %s",
+	[10] = "mixinTableAndSkipExisting - callbackFunc: %s",
+	[11] = "defaultRecursiveCallback",
+	[12] = "addEntryLSM - data: %s, subTB: %s, key: %q, valueOrCallbackFunc: %s",
+	[13] = "updateDataByFunctions - data: %s",
+	[14] = "updateDataValues - saving callback func. for key: %s",
+	[15] = "Run func. data._LSM.funcData[%q] - value: %s",
+	[16] = "updateDataValues - key: %s, setting nilToTrue: %s",
+	[17] = "getIsNew",
+	[18] = "verifyLabelString - data.name: %s",
+	[19] = "recursiveOverEntries - #submenu: %s, result: %s",
+	[20] = "silenceComboBoxClickedSound - doSilence: %s, entryType: %s",
+	[21] = "getOptionsForDropdown",
+	[22] = "playSelectedSoundCheck - entryType: %s",
+	[23] = "doMapEntries",
+	[24] = "mapEntries",
+	[25] = "updateIcon - Adding \'new icon\'",
+	[26] = "updateIcon - iconIdx %s, visible: %s, texture: %s, tint: %s, width: %s, height: %s, narration: %s",
+	[27] = "updateIcons - numIcons %s",
+	[28] = "getControlData - name:  %s",
+	[29] = "checkIfContextMenuOpenedButOtherControlWasClicked - cbox == ctxtMenu? %s; cntxt dropdownVis? %s",
+	[30] = "areAnyEntriesNew",
+	[31] = "updateSubmenuNewStatus",
+	[32] = "clearNewStatus",
+	[33] = "FireCallbacks: NewStatusUpdated - control:  %s",
+	[34] = "setItemEntryCustomTemplate - name: %q, entryType: %s",
+	[35] = "addItem_Base - itemEntry:  %s",
+	[36] = "resetCustomTooltipFuncVars",
+	[37] = "hideTooltip - custom onHide func:  %s",
+	[38] = "getTooltipAnchor - control: %s, tooltipText: %s, hasSubmenu: %s",
+	[39] = "showTooltip - control: %s, tooltipText: %s, hasSubmenu: %s, customTooltipFunc: %s",
+	[40] = "isAccessibilitySettingEnabled - settingId: %s, isSettingEnabled: %s",
+	[41] = "isAccessibilityModeEnabled",
+	[42] = "isAccessibilityUIReaderEnabled",
+	[43] = "addNewUINarrationText - newText: %s, stopCurrent: %s",
+	[44] = "onUpdateDoNarrate - updName: %s, delay: %s",
+	[45] = "onUpdateDoNarrate - Delayed call: updName: %s",
+	[46] = "onMouseEnterOrExitNarrate - narrateText: %s, stopCurrent: %s",
+	[47] = "onSelectedNarrate - narrateText: %s, stopCurrent: %s",
+	[48] = "onMouseMenuOpenOrCloseNarrate - narrateText: %s, stopCurrent: %s",
+	[49] = "onMouseEnter - control: %s, hasSubmenu: %s",
+	[50] = "FireCallbacks: EntryOnMouseEnter - control: %s, hasSubmenu: %s",
+	[51] = "onMouseExit - control: %s, hasSubmenu: %s",
+	[52] = "FireCallbacks: EntryOnMouseExit - control: %s, hasSubmenu: %s",
+	[53] = "runHandler - control: %s, handlerTable: %s, typeId: %s",
+	[54] = "createScrollableComboBoxEntry - index: %s, entryType: %s",
+	[55] = "dropdownClass:Initialize - parent: %s, comboBoxContainer: %s, depth: %s",
+	[56] = "dropdownClass:Narrate - eventName: %s, ctrl: %s, hasSubmenu: %s, anchorPoint: %s",
+	[57] = "dropdownClass:AddCustomEntryTemplate - entryTemplate: %s, entryHeight: %s, setupFunction: %s, widthPadding: %s",
+	[58] = "dropdownClass:AnchorToControl - point: %s, relativeTo: %s, relativePoint: %s offsetX: %s, offsetY: %s",
+	[59] = "dropdownClass:AnchorToComboBox - comboBox container: %s",
+	[60] = "dropdownClass:AnchorToMouse - point: %s, relativeTo: %s, relativePoint: %s offsetX: %s, offsetY: %s",
+	[61] = "dropdownClass:GetSubmenu - submenu:  %s",
+	[62] = "dropdownClass:IsDropdownVisible:  %s",
+	[63] = "dropdownClass:IsEnteringSubmenu -> Yes",
+	[64] = "dropdownClass:IsEnteringSubmenu -> No",
+	[65] = "dropdownClass:IsItemSelected ->  %s",
+	[66] = "dropdownClass:IsItemSelected -> No",
+	[67] = "dropdownClass:IsMouseOverOpeningControl -> No",
+	[68] = "dropdownClass:OnMouseEnterEntry - control:  %s",
+	[69] = "dropdownClass:OnMouseExitEntry - control:  %s",
+	[70] = "dropdownClass:OnMouseExitTimeout - control:  %s",
+	[71] = "dropdownClass:OnEntryMouseUp - control: %s, button: %s, upInside: %s",
+	[72] = "dropdownClass:OnEntryMouseUp - contextMenuCallback!",
+	[73] = "dropdownClass:SelectItemByIndex - index: %s, ignoreCallback: %s",
+	[74] = "dropdownClass:RunItemCallback - item: %s, ignoreCallback: %s",
+	[75] = "dropdownClass:Show - comboBox: %s, minWidth: %s, maxHeight: %s, spacing: %s",
+	[76] = ">totalDropDownWidth: %s, allItemsHeight: %s, desiredHeight: %s",
+	[77] = "dropdownClass:UpdateHeight",
+	[78] = "dropdownClass:OnShow",
+	[79] = "dropdownClass:OnHide",
+	[80] = "dropdownClass:ShowSubmenu - control:  %s",
+	[81] = "dropdownClass:ShowTooltip - control: %s, hasSubmenu: %s",
+	[82] = "dropdownClass:HideDropdown",
+	[83] = "dropdownClass:HideSubmenu",
+	[84] = "comboBox_base:Initialize - parent: %s, comboBoxContainer: %s, depth: %s",
+	[85] = "comboBox_base:AddItem - itemEntry: %s, updateOptions: %s, templates: %s",
+	[86] = "comboBox_base:AddCustomEntryTemplate - entryTemplate: %s, entryHeight: %s, setupFunction: %s, widthPadding: %s",
+	[87] = "getTemplateData - entryType: %s, template: %s",
+	[88] = "comboBox_base:AddCustomEntryTemplates - options: %s",
+	[89] = ">NORMAL_ENTRY_HEIGHT %s, DIVIDER_ENTRY_HEIGHT: %s, HEADER_ENTRY_HEIGHT: %s, CHECKBOX_ENTRY_HEIGHT: %s, BUTTON_ENTRY_HEIGHT: %s, RADIOBUTTON_ENTRY_HEIGHT: %s",
+	[90] = "comboBox_base:OnGlobalMouseUp-button: %s, suppressNextMouseUp: %s",
+	[91] = "comboBox_base:GetBaseHeight - control: %s, gotHeader: %s, height: %s",
+	[92] = "comboBox_base:GetMaxDropdownHeight - maxDropdownHeight: %s",
+	[93] = "comboBox_base:GetDropdownObject - comboBoxContainer: %s, depth: %s",
+	[94] = "comboBox_base:GetOptions",
+	[95] = "comboBox_base:GetSubmenu",
+	[96] = "comboBox_base:HiddenForReasons - button:  %s",
+	[97] = "comboBox_base:HideDropdown",
+	[98] = "comboBox_base:IsMouseOverControl:  %s",
+	[99] = "comboBox_base:Narrate - eventName: %s, ctrl: %s, hasSubmenu: %s, anchorPoint: %s",
+	[100] = ">narrateText: %s, stopCurrent: %s",
+	[101] = "comboBox_base:RefreshSortedItems - parentControl: %s",
+	[102] = "comboBox_base:FireEntrtCallback",
+	[103] = "comboBox_base:SetOptions",
+	[104] = "comboBox_base:SetupEntryBase - control:  %s",
+	[105] = "comboBox_base:ShowDropdownOnMouseAction - parentControl: %s  %s",
+	[106] = "comboBox_base:ShowSubmenu - parentControl: %s  %s",
+	[107] = "comboBox_base:UpdateHeight - control: %q, maxHeight: %s, maxDropdownHeight: %s, maxHeightByEntries: %s, baseEntryHeight: %s, maxRows: %s, spacing: %s, headerHeight: %s",
+	[108] = "applyEntryFont - control: %s, font: %s, color: %s, horizontalAlignment: %s",
+	[109] = "addIcon - control: %s, list: %s,",
+	[110] = "addArrow - control: %s, list: %s,",
+	[111] = "addDivider - control: %s, list: %s,",
+	[112] = "addLabel - control: %s, list: %s,",
+	[113] = "comboBox_base:SetupEntryDivider - control: %s, list: %s,",
+	[114] = "comboBox_base:SetupEntryLabelBase - control: %s, list: %s,",
+	[115] = "comboBox_base:SetupEntryLabel - control: %s, list: %s,",
+	[116] = "comboBox_base:SetupEntrySubmenu - control: %s, list: %s",
+	[117] = "comboBox_base:SetupEntryHeader - control: %s, list: %s",
+	[118] = "comboBox_base:SetupEntryRadioButton - control: %s, list: %s",
+	[119] = "comboBox_base:SetupEntryRadioButton - calling radiobutton callback, control: %s, checked: %s, list: %s",
+	[120] = "FireCallbacks: RadioButtonUpdated - control: %q, checked: %s",
+	[121] = "comboBox_base:SetupEntryCheckbox - control: %s, list: %s",
+	[122] = "comboBox_base:SetupEntryCheckbox - calling checkbox callback, control: %s, checked: %s, list: %s",
+	[123] = "FireCallbacks: CheckboxUpdated - control: %q, checked: %s",
+	[124] = "comboBox_base:SetupEntryButton - control: %s, list: %s",
+	[125] = "comboBox_base:GetMaxRows",
+	[126] = "comboBoxClass:Initialize - parent: %s, comboBoxContainer: %s, depth: %s",
+	[127] = "comboBoxClass:AddMenuItems",
+	[128] = "comboBoxClass:GetMaxRows:  %s",
+	[129] = "comboBoxClass:GetMenuPrefix: Menu",
+	[130] = "comboBoxClass:GetHiddenForReasons - button:  %s",
+	[131] = "comboBoxClass:HideDropdown",
+	[132] = "comboBoxClass:HideOnMouseEnter",
+	[133] = "comboBoxClass:HideOnMouseExit",
+	[134] = "comboBoxClass:ResetToDefaults",
+	[135] = "comboBoxClass:SetOption . key: %s, ZO_ComboBox[key]: %s",
+	[136] = "comboBoxClass:UpdateOptions - options: %s, onInit: %s, optionsChanged: %s",
+	[137] = "comboBoxClass:UpdateMetatable - parent: %s, comboBoxContainer: %s, options: %s",
+	[138] = "FireCallbacks: OnDropdownMenuAdded - control: %s, options: %s",
+	[139] = "comboBoxClass:UpdateDropdownHeader - options: %s, toggleButton: %s",
+	[140] = "submenuClass:Initialize - parent: %s, comboBoxContainer: %s, depth: %s",
+	[141] = "submenuClass:UpdateOptions - options: %s, onInit: %s",
+	[142] = "submenuClass:AddMenuItems - parentControl: %s",
+	[143] = "submenuClass:GetMaxRows:  %s",
+	[144] = "submenuClass:GetMenuPrefix: SubMenu",
+	[145] = "submenuClass:HideDropdownInternal",
+	[146] = ">submenuClass:HideDropdownInternal - onHideDropdownCallback called",
+	[147] = "submenuClass:HideOnMouseExit - mocCtrl: %s",
+	[148] = "submenuClass:GetHiddenForReasons - button:  %s",
+	[149] = "contextMenuClass:Initialize - comboBoxContainer: %s",
+	[150] = "contextMenuClass:AddContextMenuItem - itemEntry: %s, updateOptions: %s",
+	[151] = "contextMenuClass:AddMenuItems",
+	[152] = "contextMenuClass:ClearItems",
+	[153] = "contextMenuClass:GetMenuPrefix: Contextmenu",
+	[154] = "contextMenuClass:GetHiddenForReasons - button:  %s",
+	[155] = "contextMenuClass:HideDropdown",
+	[156] = "contextMenuClass:ShowSubmenu - parentControl: %s",
+	[157] = "contextMenuClass:ShowContextMenu - parentControl: %s",
+	[158] = "contextMenuClass:SetContextMenuOptions - options: %s",
+	[159] = "GetPersistentMenus: %s",
+	[160] = "SetPersistentMenus - persistent: %s",
+	[161] = "AddCustomScrollableComboBoxDropdownMenu - parent: %s, comboBoxContainer: %s, options: %s",
+	[162] = "AddCustomScrollableMenuEntry - text: %s, callback: %s, entryType: %s, entries: %s",
+	[163] = "AddCustomScrollableSubMenuEntry - text: %s, entries: %s",
+	[164] = "AddCustomScrollableMenuDivider",
+	[165] = "AddCustomScrollableMenuHeader-text: %s",
+	[166] = "AddCustomScrollableMenuCheckbox-text: %s, checked: %s",
+	[167] = "SetCustomScrollableMenuOptions - comboBoxContainer: %s, options: %s",
+	[168] = "ClearCustomScrollableMenu",
+	[169] = "AddCustomScrollableMenuEntries - contextMenuEntries: %s",
+	[170] = "AddCustomScrollableMenu - entries: %s, options: %s",
+	[171] = "ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s",
+	[172] = "FireCallbacks: ContextMenu - OnDropdownMenuAdded - control: %s, options: %s",
+	[173] = "m_button OnMouseUp!",
+	[174] = "~~~~~ onAddonLoaded ~~~~~",
+	[175] = "ZO_Menu -> ShowMenu. Items#: %s, menuType:  %s",
+	[176] = "Debugging turned %s",
+	[177] = "Verbose debugging turned %s / Debugging: %s",
+}
+
+
+------------------------------------------------------------------------------------------------------------------------
+-- Logger creation
+------------------------------------------------------------------------------------------------------------------------
+local function loadLogger()
+	--LibDebugLogger
+	LDL = LDL or LibDebugLogger
+	if not lib.logger and LDL then
+		logger = LDL(MAJOR)
+		logger:SetEnabled(true)
+		logger:Debug("Library loaded")
+		logger.verbose = logger:Create("Verbose")
+		logger.verbose:SetEnabled(false)
+
+		logger.callbacksFired = logger:Create("Callbacks")
+
+		lib.Debug.logger = logger
+	end
+end
+lib.LoadLogger = loadLogger
+
+
+--Early try to load libs and to create logger (done again in EVENT_ADD_ON_LOADED)
+loadLogger()
+
+
+------------------------------------------------------------------------------------------------------------------------
+-- Logging functions
+------------------------------------------------------------------------------------------------------------------------
+--Debug log function
+local function dlog(debugType, textId, ...)
+	if not lib.doDebug or not textId then return end
+	debugType = debugType or LSM_LOGTYPE_DEBUG
+
+	local debugText = debugLogMessagePatterns[textId]
+	if ... ~= nil and select(1, {...}) ~= nil then
+		debugText = sfor(debugText, ...)
+	end
+	if debugText == nil or debugText == "" then return end
+
+	--LibDebugLogger
+	if LDL then
+		if debugType == LSM_LOGTYPE_DEBUG_CALLBACK then
+			logger.callbacksFired:Debug(debugText)
+
+		elseif debugType == LSM_LOGTYPE_DEBUG then
+			logger:Debug(debugText)
+
+		elseif debugType == LSM_LOGTYPE_VERBOSE then
+			if lib.doVerboseDebug then
+				local loggerVerbose = logger.verbose
+				if loggerVerbose and loggerVerbose.isEnabled == true then
+					loggerVerbose:Verbose(debugText)
+				end
+			end
+
+		elseif debugType == LSM_LOGTYPE_INFO then
+			logger:Info(debugText)
+
+		elseif debugType == LSM_LOGTYPE_ERROR then
+			logger:Error(debugText)
+		end
+
+	--Normal debugging via chat d() messages
+	else
+		--No verbose debuglos in normal chat!
+		if debugType ~= LSM_LOGTYPE_VERBOSE then
+			local debugTypePrefix = loggerTypeToName[debugType] or ""
+			d(debugPrefix .. debugTypePrefix .. debugText)
+		end
+	end
+end
+lib.DebugLog = dlog


### PR DESCRIPTION
-v- ---------------LSM v2.33 - 2024-12-21---------------------------------------------------------------------------- -v-
-Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
-Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
-Bug fix: XMLRowTemplates using a non capital R at some locations
-Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
-Bug fix: options.headerFont and headerColor work now
-Changed: XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
-Changed: handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
-Changed: Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled
-Added: options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType
-Added: return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
-Renamed: API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
-Renamed: self.optionsData at contextMenus was properly renamed to self.contextMenuOptions