### PR TITLE
LSM v2.33 FINAL 3

### DIFF
--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -155,13 +155,13 @@ local function test()
 				},
 				[lib.LSM_ENTRY_TYPE_SUBMENU] = {
 					template = lib.LSM_ROW_HIGHLIGHT_DEFAULT, --"ZO_SelectionHighlight", --Will be replaced with green if submenu entry got callback
-					templateWithCallback = lib.LSM_ROW_HIGHLIGHT_OPAQUE,
+					templateSubMenuWithCallback = lib.LSM_ROW_HIGHLIGHT_OPAQUE,
 					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
 				},
 				[lib.LSM_ENTRY_TYPE_CHECKBOX] = {
-					template = lib.LSM_ROW_HIGHLIGHT_DEFAULT, --"LibScrollableMenu_Highlight_Blue",
+					template = lib.LSM_ROW_HIGHLIGHT_RED, --"LibScrollableMenu_Highlight_Blue",
 					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
-					templateContextMenuOpeningControl = lib.LSM_ROW_HIGHLIGHT_BLUE,
+					templateContextMenuOpeningControl = lib.LSM_ROW_HIGHLIGHT_OPAQUE,
 				},
 				[lib.LSM_ENTRY_TYPE_BUTTON] = {
 					template = lib.LSM_ROW_HIGHLIGHT_RED, --"LibScrollableMenu_Highlight_Red",
@@ -890,7 +890,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 							},
 							[lib.LSM_ENTRY_TYPE_SUBMENU] = {
 								template = lib.LSM_ROW_HIGHLIGHT_DEFAULT, --"ZO_SelectionHighlight", --Will be replaced with green if submenu entry got callback
-								templateWithCallback = lib.LSM_ROW_HIGHLIGHT_BLUE,
+								templateSubMenuWithCallback = lib.LSM_ROW_HIGHLIGHT_BLUE,
 								color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
 							},
 							[lib.LSM_ENTRY_TYPE_CHECKBOX] = {

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -155,13 +155,13 @@ local function test()
 				},
 				[lib.LSM_ENTRY_TYPE_SUBMENU] = {
 					template = lib.LSM_ROW_HIGHLIGHT_DEFAULT, --"ZO_SelectionHighlight", --Will be replaced with green if submenu entry got callback
-					templateWithCallback = lib.LSM_ROW_HIGHLIGHT_BLUE,
+					templateWithCallback = lib.LSM_ROW_HIGHLIGHT_OPAQUE,
 					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
 				},
 				[lib.LSM_ENTRY_TYPE_CHECKBOX] = {
-					template = lib.LSM_ROW_HIGHLIGHT_BLUE, --"LibScrollableMenu_Highlight_Blue",
+					template = lib.LSM_ROW_HIGHLIGHT_DEFAULT, --"LibScrollableMenu_Highlight_Blue",
 					color = CUSTOM_HIGHLIGHT_TEXT_COLOR,
-					templateContextMenuOpeningControl = lib.LSM_ROW_HIGHLIGHT_RED,
+					templateContextMenuOpeningControl = lib.LSM_ROW_HIGHLIGHT_BLUE,
 				},
 				[lib.LSM_ENTRY_TYPE_BUTTON] = {
 					template = lib.LSM_ROW_HIGHLIGHT_RED, --"LibScrollableMenu_Highlight_Red",

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -5931,7 +5931,7 @@ LibScrollableMenu = lib
 
 --[[
 -------------------
-WORKING ON - Current version: 2.33 - Updated 2024-12-16
+WORKING ON - Current version: 2.33 - Updated 2024-12-28
 -------------------
 -Bug fix: 	Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 -Bug fix: 	Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
@@ -5939,6 +5939,7 @@ WORKING ON - Current version: 2.33 - Updated 2024-12-16
 -Bug fix: 	Fire the OnDropdownMenuAdded callback for the contextMenu too
 -Bug fix: 	options.headerFont and headerColor work now and do not use m_headerFont etc. anymore to pass in the options
 -Bug fix: 	Hide the tooltip as checkbox is toggled, or radioButton is changed
+-Bug fix: 	Pool controls did not reapply the proper highlight upon scrolling and re-usage of the controls
 -Changed: 	XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
 -Changed: 	handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
 -Changed: 	Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled
@@ -5948,8 +5949,6 @@ WORKING ON - Current version: 2.33 - Updated 2024-12-16
 -Renamed: 	self.optionsData at contextMenus was properly renamed to self.contextMenuOptions
 
 
-TODO Bug: Submenu Entry Test 7 and 7 apply the same data.m_highlihtTemplate (as we scroll down) as the first and 2nd row of the submenu used. Setupcallback is not resetting them upon scrolling
---todo    because the row control is the same as the 1st "LibScrollableMenuTestDropdown2Scroll3Row1" > Needs to update ScrollHighlightAnimation control upon scrolling! See function unhighlightControl
 
 
 -------------------

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -3980,12 +3980,6 @@ end
 function comboBox_base:GetHighlightTemplateData(control, m_data, isSubMenu, isContextMenu)
 	local entryType = control.typeId
 
---[[
-	local doDebug = control:GetName() == "LibScrollableMenuTestDropdown1Scroll11Row1"
-	if doDebug then
-		d(debugPrefix .. "comboBox_base:GetHighlightTemplateData - control: " .. tos(getControlName(control)))
-	end
-]]
 	--Get the highlight template based on the entryType
 	if entryType == nil then return	end
 
@@ -3994,19 +3988,6 @@ function comboBox_base:GetHighlightTemplateData(control, m_data, isSubMenu, isCo
 	local highlightTemplateData = ((self.XMLRowHighlightTemplates[entryType] ~= nil and ZO_ShallowTableCopy(self.XMLRowHighlightTemplates[entryType])) or (appliedHighlightTemplateCopy)) or ZO_ShallowTableCopy(defaultHighlightTemplateData) --loose the reference so we can overwrite values below, without changing originals
 	highlightTemplateData.overwriteHighlightTemplate = highlightTemplateData.overwriteHighlightTemplate or false
 
---[[
-	if doDebug then
-LSM_Debug = {
-	highlightTemplateData = highlightTemplateData,
-	highlightTemplateDataCopy = ZO_ShallowTableCopy(highlightTemplateData),
-	XMLRowHighlightTemplatesEntryType = ZO_ShallowTableCopy(self.XMLRowHighlightTemplates[entryType]),
-	appliedHighlightTemplate = appliedHighlightTemplate,
-	defaultHighlightTemplateData = defaultHighlightTemplateData
-}
-
-		d(">entryType: " .. tos(entryType) .. "; template: " ..tos(self.XMLRowHighlightTemplates[entryType].template) .."; CntxMenOpenTemplate: " .. tos(self.XMLRowHighlightTemplates[entryType].templateContextMenuOpeningControl) .. "; appliedHighlightTemplate: " .. tos(appliedHighlightTemplateCopy.template) .. "; defTemplate: " .. tos(defaultHighlightTemplateData.template))
-	end
-]]
 	local options = self:GetOptions()
 	local data = getControlData(control)
 
@@ -4016,11 +3997,6 @@ LSM_Debug = {
 		local origData = data[LSM_DATA_SUBTABLE] and data[LSM_DATA_SUBTABLE][LSM_DATA_SUBTABLE_ORIGINAL_DATA] and data[LSM_DATA_SUBTABLE][LSM_DATA_SUBTABLE_ORIGINAL_DATA].data
 		if origData then
 			if origData.m_highlightTemplate or origData.m_highlightColor then
---[[
-if doDebug then
-d(">Original data highlightTemplate was found")
-end
-]]
 				local origHighlightTemplateData = {}
 				origHighlightTemplateData.template = 	origData.m_highlightTemplate
 				origHighlightTemplateData.color = 		origData.m_highlightColor or defaultHighlightColor
@@ -4047,12 +4023,6 @@ end
 			local isOwnedByContextMenuComboBox = g_contextMenu.m_dropdownObject:IsOwnedByComboBox(comboBox)
 
 			if gotRightCLickCallback and not isOwnedByContextMenuComboBox then
---[[
-if doDebug then
-	d("[GetHighlightTemplateData]cntxtMenu: " .. tos(isContextMenuAndHighlightContextMenuOpeningControl) ..", dataRightClick: " .. tos(gotRightCLickCallback) .. "; isOwnedByCntxtMenuCBox: " ..tos(isOwnedByContextMenuComboBox))
-	d(">template: " ..tos(highlightTemplateData.template) .."; CntxMenOpenTemplate: " .. tos(highlightTemplateData.templateContextMenuOpeningControl) .. "; appliedHighlightTemplate: " .. tos(appliedHighlightTemplateCopy) .. "; defTemplate: " .. tos(defaultHighlightTemplateDataEntryContextMenuOpeningControl.template))
-end
-]]
 
 				--highlightContextMenuOpeningControl support -> highlightTemplateData.templateContextMenuOpeningControl
 				highlightTemplateData.template = ((highlightTemplateData.templateContextMenuOpeningControl ~= nil and highlightTemplateData.templateContextMenuOpeningControl) or (appliedHighlightTemplateCopy)) or ZO_ShallowTableCopy(defaultHighlightTemplateDataEntryContextMenuOpeningControl).template
@@ -4066,23 +4036,10 @@ end
 --Write the highlight template to the control.m_data.m_highlightTemplate (ZO_ComboBox default variable for that), based
 --on the XMLRowHighlightTemplates passed in via the options (or using default values)
 function comboBox_base:UpdateHighlightTemplate(control, data, isSubMenu, isContextMenu)
---[[
-	local doDebug = control:GetName() == "LibScrollableMenuTestDropdown1Scroll11Row1"
-	if doDebug then
-		d("+++++++++++++++++++++++++++++++++++++++++++++")
-		d(debugPrefix .. "UpdateHighlightTemplate - name: " .. tos(getControlName(control)) .. ", entryType: " .. tos(control.typeId) .. ", isContextMenu: " .. tos(isContextMenu))
-	end
-]]
 
 	isContextMenu = isContextMenu or self.isContextMenu
 	local highlightTemplateData = self:GetHighlightTemplateData(control, data, isSubMenu, isContextMenu)
 	local highlightTemplate = (highlightTemplateData ~= nil and highlightTemplateData.template) or nil
-
---[[
-	if doDebug then
-		d(">HL_Template: " .. tos(highlightTemplate) .. "; color: " .. tos(highlightTemplateData.color) .. ", overwrite: " .. tos(highlightTemplateData.overwriteHighlightTemplate))
-	end
-]]
 
 	if control.m_data then
 		if highlightTemplateData == nil then
@@ -4091,13 +4048,6 @@ function comboBox_base:UpdateHighlightTemplate(control, data, isSubMenu, isConte
 		elseif highlightTemplateData.overwriteHighlightTemplate == true or not control.m_data.m_highlightTemplate then
 			control.m_data.m_highlightTemplate = highlightTemplate
 			control.m_data.m_highlightColor = highlightTemplateData.color
-
---[[
-			if doDebug then
-				d(">>highlight template was applied to m_data.m_highlightTemplate")
-				d("----------------------------------------------")
-			end
-]]
 		end
 	end
 end

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -23,4 +23,4 @@ LibScrollableMenu.xml
 ## Uncomment this to test the combobox with different menu entryTypes and submenus
 ## Use slash command /lsmtest to show the test UI
 ## Inspect the code in LSM_test.lua file to see how the API functions etc. work
-LSM_test.lua
+## LSM_test.lua

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,10 +1,11 @@
--v- ---------------LSM v2.33 - 2024-12-23---------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.33 - 2024-12-28---------------------------------------------------------------------------- -v-
 -Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 -Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
 -Bug fix: XMLRowTemplates using a non capital R at some locations
 -Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
 -Bug fix: options.headerFont and headerColor work now and do not use m_headerFont etc. anymore to pass in the options
 -Bug fix: Hide the tooltip as checkbox is toggled, or radioButton is changed
+-Bug fix: 	Pool controls did not reapply the proper highlight upon scrolling and re-usage of the controls
 -Changed: XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
 -Changed: handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
 -Changed: Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled


### PR DESCRIPTION
-v- ---------------LSM v2.33 - 2024-12-28---------------------------------------------------------------------------- -v-
-Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
-Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
-Bug fix: XMLRowTemplates using a non capital R at some locations
-Bug fix: Fire the OnDropdownMenuAdded callback for the contextMenu too
-Bug fix: options.headerFont and headerColor work now and do not use m_headerFont etc. anymore to pass in the options
-Bug fix: Hide the tooltip as checkbox is toggled, or radioButton is changed
-Bug fix: 	Pool controls did not reapply the proper highlight upon scrolling and re-usage of the controls
-Changed: XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
-Changed: handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
-Changed: Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled
-Added: options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType
-Added: return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
-Renamed: API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
-Renamed: self.optionsData at contextMenus was properly renamed to self.contextMenuOptions
