### PR TITLE
Version 2 3 4

### DIFF
--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -97,8 +97,10 @@ local function test()
 		local options = {
 			enableMultiSelect = true, --todo 20250127 test
 			maxNumSelections = 2,
-			multiSelectionTextFormatter = 	"<<1[$d item/$d items]>> selected",
-			noSelectionText = 				"No item selected",
+			maxNumSelectionsErrorText =		"[LSM]ERROR - Maximum items selected already",
+			multiSelectionTextFormatter = 	"<<$d>> selected",
+			noSelectionText = 				"",
+			OnSelectionBlockedCallback = function() d("[LSM]ERROR - Selection of entry was blocked!") end,
 
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -97,10 +97,10 @@ local function test()
 		local options = {
 			enableMultiSelect = true, --todo 20250127 test
 			maxNumSelections = 2,
-			maxNumSelectionsErrorText =		"[LSM]ERROR - Maximum items selected already",
-			multiSelectionTextFormatter = 	"<<$d>> selected",
+			maxNumSelectionsErrorText =		debugPrefix.."ERROR - Maximum items selected already",
+			multiSelectionTextFormatter = 	"<<1>> selected",
 			noSelectionText = 				"",
-			OnSelectionBlockedCallback = function() d("[LSM]ERROR - Selection of entry was blocked!") end,
+			OnSelectionBlockedCallback = function() d(debugPrefix.."ERROR - Selection of entry was blocked!") end,
 
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -98,7 +98,7 @@ local function test()
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
-			maxDropdownWidth = 400,
+			--maxDropdownWidth = 400, -- todo 20250126 submenu width is kind of 0? Is this the fault of this option?
 
 			--Big yellow headers!
 			--headerFont = "ZoFontHeader3",

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -98,6 +98,7 @@ local function test()
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
+			maxDropdownWidth = 200,
 
 			--Big yellow headers!
 			--headerFont = "ZoFontHeader3",

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -98,7 +98,7 @@ local function test()
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
-			maxDropdownWidth = 200,
+			maxDropdownWidth = 400,
 
 			--Big yellow headers!
 			--headerFont = "ZoFontHeader3",

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -98,7 +98,7 @@ local function test()
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
-			--maxDropdownWidth = 400, -- todo 20250126 submenu width is kind of 0? Is this the fault of this option?
+			maxDropdownWidth = 450,
 
 			--Big yellow headers!
 			--headerFont = "ZoFontHeader3",

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -98,7 +98,7 @@ local function test()
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
-			maxDropdownWidth = 450,
+			maxDropdownWidth = 20,
 
 			--Big yellow headers!
 			--headerFont = "ZoFontHeader3",

--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -95,10 +95,15 @@ local function test()
 		-- Options for the main combobox menu
 		--==============================================================================================================
 		local options = {
+			enableMultiSelect = true, --todo 20250127 test
+			maxNumSelections = 2,
+			multiSelectionTextFormatter = 	"<<1[$d item/$d items]>> selected",
+			noSelectionText = 				"No item selected",
+
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
-			maxDropdownWidth = 20,
+			--maxDropdownWidth = 450,
 
 			--Big yellow headers!
 			--headerFont = "ZoFontHeader3",

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -6122,44 +6122,67 @@ LibScrollableMenu = lib
 
 
 ------------------------------------------------------------------------------------------------------------------------
--- Notes: | TODO:
+-- Notes | Changelog | TODO | UPCOMING FEATURES
 ------------------------------------------------------------------------------------------------------------------------
 
 --[[
--------------------
-WORKING ON - Current version: 2.34 - Updated 2025-01-27
--------------------
-#2501_3. Support Multiselect properly (works at normal main menu)
-Bugs:
---Initial text for noSelectionText is shown as default text of ZO_ComboBox and not updated from options properly
---Submenus do close upon selection of an entry (maybe due to ZO_ComboBox:SelectItem -> calling :Refresh ?)
+---------------------------------------------------------------
+	NOTES
+---------------------------------------------------------------
+
+
+
+---------------------------------------------------------------
+	CHANGELOG Current version: 2.34 - Updated 2025-01-27
+---------------------------------------------------------------
+
+[WORKING ON]
+#2501_3. Support Multiselect properly
+-Added options.enableMultiSelect
+-Added options.maxNumSelections
+-Added options.maxNumSelectionsErrorText
+-Added options.multiSelectionTextFormatter
+-Added options.noSelectionText
+-Added options.OnSelectionBlockedCallback
+
+2501_3 Bugs:
+a) Initial text for noSelectionText is shown as default text of ZO_ComboBox and not updated from options.noSelectionText properly
+b) Submenus do close upon selection of an entry (maybe due to ZO_ComboBox:SelectItem -> calling dropdownObject:Refresh ?)
+    -- refresh the data that was just selected so the selection highlight properly shows/hides
+    if self.m_dropdownObject:IsOwnedByComboBox(self) then
+        self.m_dropdownObject:Refresh(item)
+    end
+
+
 	---> It will be called from dropdownClass:OnEntryMouseUp, and then call the ZO_ComboBoxDropdown_Keyboard.OnEntrySelected -> ZO_ComboBox:SetSelected -> ZO_ComboBox:SelectItem -> then:
 	-----> If no multiselection is enabled: ZO_ComboBox_Base.SelectItem -> ZO_ComboBox_Base:ItemSelectedClickHelper(item, ignoreCallback) -> item.callback(comboBox, itemName, item, selectionChanged, oldItem) function
 	-----> If multiselection is enabled: ZO_ComboBox:SelectItem contains the code via self:AddItemToSelected etc.
---Submenus do not show the selected highlight as they open again
+c) Submenus do not show the selected highlight as they open again (maybe related to b)?)
 
 
 [Fixed]
 #2501_1. Fix header with searchbox to have a minimum width
 
 [Added]
-#2501_2. Added option "maxDropdownWidth"
+#2501_2. Added option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled).
+		 If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
 
 [Changed]
 
+[Removed]
 
--------------------
+
+---------------------------------------------------------------
 TODO - To check (future versions)
--------------------
+---------------------------------------------------------------
 	1. Make Options update same style like updateDataValues does for entries
 	2. Attention: zo_comboBox_base_hideDropdown(self) in self:HideDropdown() does NOT close the main dropdown if right clicked! Only for a left click... See ZO_ComboBox:HideDropdownInternal()
 	3. verify submenu anchors. Small adjustments not easily seen on small laptop monitor
 	- fired on handlers dropdown_OnShow dropdown_OnHide
 
-
--------------------
+---------------------------------------------------------------
 UPCOMING FEATURES  - What could be added in the future?
--------------------
+---------------------------------------------------------------
 	1. Sort headers for the dropdown (ascending/descending) (maybe: allowing custom sort functions too)
 	2. LibCustomMenu and ZO_Menu replacement (currently postponed, see code at branch LSM v2.4) due to several problems with ZO_Menu (e.g. zo_callLater used by addons during context menu addition) and chat, and other problems
 ]]

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -9,7 +9,7 @@ lib.name = "LibScrollableMenu"
 local MAJOR = lib.name
 
 lib.author = "IsJustaGhost, Baertram, tomstock, Kyoma"
-lib.version = "2.33"
+lib.version = "2.34"
 
 if not lib then return end
 
@@ -5945,23 +5945,10 @@ LibScrollableMenu = lib
 
 --[[
 -------------------
-WORKING ON - Current version: 2.33 - Updated 2024-12-28
+WORKING ON - Current version: 2.34 - Updated 2025-01-25
 -------------------
--Bug fix: 	Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
--Bug fix: 	Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
--Bug fix: 	XMLRowTemplates using a non capital R at some locations
--Bug fix: 	Fire the OnDropdownMenuAdded callback for the contextMenu too
--Bug fix: 	options.headerFont and headerColor work now and do not use m_headerFont etc. anymore to pass in the options
--Bug fix: 	Hide the tooltip as checkbox is toggled, or radioButton is changed
--Bug fix: 	Pool controls did not reapply the proper highlight upon scrolling and re-usage of the controls
--Changed: 	XML handlers for the header's text search etc. to call one LSM function to reduce redundant code
--Changed: 	handlers On(Sub/Context)MenuShow and Hide will provide the dropdownObject as 2nd parameter now (sames as 1st parameter's dropdownControl.m_dropdownObject)
--Changed: 	Moved debug messages to a table and use the index of the message instead of sending the whole text on each debug message, plus orevent calling debug messages if debugging is disbled
--Added: 	options.XMLRowHighlightTemplates for row highlight XML virtual templates and colors (on mouse enter) per entryType.
--Added: 	return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
--Renamed: 	API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
--Renamed: 	self.optionsData at contextMenus was properly renamed to self.contextMenuOptions
-
+-Support Multiselect properly
+-Fix header with searchbox to have a minimum width (to show the search box and button properly)
 
 
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -659,6 +659,7 @@ local submenuClass_exposedVariables = {
 --If submenuClass_exposedFunctions[variable] == true: if submenuClass[key] is not nil, returns submenuClass[key](submenu.m_comboBox, ...)
 local submenuClass_exposedFunctions = {
 	["SelectItem"] = true, -- (item, ignoreCallback)
+	["IsItemSelected"] = true,
 }
 
 
@@ -2796,7 +2797,7 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	]]
 	-->!!! This will be the place where the function HighlightControl above calls the highlightTemplateOrFunction function !!!
 	scrollCtrl.highlightTemplateOrFunction = function(control)
-d(debugPrefix .. "scrollCtrl.highlightTemplateOrFunction - " .. tos(getControlName(control)))
+--d(debugPrefix .. "scrollCtrl.highlightTemplateOrFunction - " .. tos(getControlName(control)))
 		if selfVar.owner then
 			--return selfVar.owner:GetHighlightTemplate(control)
 			local XMLVirtualHighlightTemplateOfRow = selfVar.owner:GetHighlightTemplate(control)
@@ -3855,7 +3856,7 @@ local function getDefaultXMLTemplates(selfVar)
 			template = 'LibScrollableMenu_ComboBoxEntry',
 			rowHeight = ZO_COMBO_BOX_ENTRY_TEMPLATE_HEIGHT,
 			setupFunc = function(control, data, list)
-d(debugPrefix .. "XMLtemplate LSM_ENTRY_TYPE_NORMAL, setupFunc")
+--d(debugPrefix .. "XMLtemplate LSM_ENTRY_TYPE_NORMAL, setupFunc")
 				selfVar:SetupEntryLabel(control, data, list, LSM_ENTRY_TYPE_NORMAL)
 			end,
 		},
@@ -4274,7 +4275,7 @@ function comboBox_base:UpdateHighlightTemplate(control, data, isSubMenu, isConte
 	isContextMenu = isContextMenu or self.isContextMenu
 	local highlightTemplateData = self:GetHighlightTemplateData(control, data, isSubMenu, isContextMenu)
 	local highlightTemplate = (highlightTemplateData ~= nil and highlightTemplateData.template) or nil
-d(debugPrefix .. "UpdateHighlightTemplate - highlightTemplateData: " .. tos(highlightTemplateData) .. ", override: " .. tos(highlightTemplateData and highlightTemplateData.overwriteHighlightTemplate) .. "; current: " .. tos(control.m_data.m_highlightTemplate))
+--d(debugPrefix .. "UpdateHighlightTemplate - highlightTemplateData: " .. tos(highlightTemplateData) .. ", override: " .. tos(highlightTemplateData and highlightTemplateData.overwriteHighlightTemplate) .. "; current: " .. tos(control.m_data.m_highlightTemplate))
 	if control.m_data then
 		if highlightTemplateData == nil then
 			control.m_data.m_highlightTemplate = nil --defaultHighlightTemplateData.template ???

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -6254,7 +6254,7 @@ LibScrollableMenu = lib
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.34 - Updated 2025-01-27
+	CHANGELOG Current version: 2.34 - Updated 2025-02-04
 ---------------------------------------------------------------
 
 [WORKING ON]
@@ -6267,14 +6267,13 @@ LibScrollableMenu = lib
 -Added options.OnSelectionBlockedCallback
 
 2501_3 Bugs:
-a) OPEN - Initial text for noSelectionText is shown as default text of ZO_ComboBox and not updated from options.noSelectionText properly
+a) FIXED - Initial text for noSelectionText is shown as default text of ZO_ComboBox and not updated from options.noSelectionText properly
 b) FIXED - Submenus do close upon selection of an entry
 	--20250129 Reason: m_enableMultiSelect was set = false in submenu initialization and thus the metatable lookup from parent LSM combobox was not used!
 	-------> Also: Workaround implemented into dropdownClass:OnEntryMouseUp: checking self.owner.m_parentMenu.m_enableMultiSelect and using this for the submenu
 
 c) FIXED - Submenus do not show the selected highlight if multiselection is enabled, and they do not show as they open again
 	--20250203 Reason: dropdownClass:Refresh needed to account for scrollControl of submenus, and m_multiSelectItemData must be read from parentMenu, and not set = {} at each submenu again!
-d) Open - Nested submenus do not update the selected entries highlight directly, but first as the submenu reopens (mouse moved away and back to it)
 
 
 [Fixed]

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -2734,7 +2734,7 @@ end
 -- dropdownClass
 --------------------------------------------------------------------
 
-local dropdownClass = ZO_ComboBoxDropdown_Keyboard:Subclass()
+local dropdownClass = ZO_ComboBoxDropdown_Keyboard:Subclass() --vanilla: XML ZO_ComboBoxDropdown_Singleton_Keyboard -> XML ZO_ComboBoxDropdown_Keyboard_Template -> ZO_ComboBoxDropdown_Keyboard.InitializeFromControl(self)
 
 -- dropdownClass:New(To simplify locating the beginning of the class
 function dropdownClass:Initialize(parent, comboBoxContainer, depth)
@@ -3200,7 +3200,7 @@ function dropdownClass:Show(comboBox, itemTable, minWidth, maxWidth, maxHeight, 
 	--Check if a minWidth is > than totalDropDownWidth
 	local desiredWidth = zo_clamp(totalDropDownWidth, minWidth, totalDropDownWidth)
 
-d(">[LSM]dropdownClass:Show - minWidth: " .. tos(minWidth) ..", maxDropdownWidth: " .. tos(maxDropdownWidth) ..", maxWidth: " .. tos(maxWidth) .. ", totalDropDownWidth: " .. tos(totalDropDownWidth) .. ", longestEntryTextWidth: " ..tos(longestEntryTextWidth) ..", desiredWidth: " .. tos(desiredWidth))
+--d(">[LSM]dropdownClass:Show - minWidth: " .. tos(minWidth) ..", maxDropdownWidth: " .. tos(maxDropdownWidth) ..", maxWidth: " .. tos(maxWidth) .. ", totalDropDownWidth: " .. tos(totalDropDownWidth) .. ", longestEntryTextWidth: " ..tos(longestEntryTextWidth) ..", desiredWidth: " .. tos(desiredWidth))
 
 	--maxHeight should have been defined before via self:UpdateHeight() -> Settings control:SetHeight() so self.m_height was set
 	local desiredHeight = maxHeight
@@ -3276,22 +3276,6 @@ function dropdownClass:OnHide(formattedEventName)
 	end
 end
 
---Called from XML "LibScrollableMenu_Dropdown_Behavior"
-function dropdownClass:XMLHandler(selfVar, handlerName)
-	if selfVar == nil or handlerName == nil then return end
-
-	if handlerName == "OnEffectivelyHidden" then
-		self:HideDropdown()
-	elseif handlerName == "OnMouseEnter" then
-		self:OnMouseExitTimeout(selfVar)
-
-	elseif handlerName == "OnShow" then
-		self:OnShow(self:GetFormattedNarrateEvent('Show'))
-	elseif handlerName == "OnHide" then
-		self:OnHide(self:GetFormattedNarrateEvent('Hide'))
-	end
-end
-
 function dropdownClass:ShowSubmenu(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 80, tos(getControlName(control))) end
 	if self.owner then
@@ -3318,6 +3302,22 @@ function dropdownClass:HideSubmenu()
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 83) end
 	if self.m_submenu and self.m_submenu:IsDropdownVisible() then
 		self.m_submenu:HideDropdown()
+	end
+end
+
+--Called from XML "LibScrollableMenu_Dropdown_Behavior"
+function dropdownClass:XMLHandler(selfVar, handlerName)
+	if selfVar == nil or handlerName == nil then return end
+
+	if handlerName == "OnEffectivelyHidden" then
+		self:HideDropdown()
+	elseif handlerName == "OnMouseEnter" then
+		self:OnMouseExitTimeout(selfVar)
+
+	elseif handlerName == "OnShow" then
+		self:OnShow(self:GetFormattedNarrateEvent('Show'))
+	elseif handlerName == "OnHide" then
+		self:OnHide(self:GetFormattedNarrateEvent('Hide'))
 	end
 end
 
@@ -6147,12 +6147,7 @@ LibScrollableMenu = lib
 
 2501_3 Bugs:
 a) Initial text for noSelectionText is shown as default text of ZO_ComboBox and not updated from options.noSelectionText properly
-b) Submenus do close upon selection of an entry (maybe due to ZO_ComboBox:SelectItem -> calling dropdownObject:Refresh ?)
-    -- refresh the data that was just selected so the selection highlight properly shows/hides
-    if self.m_dropdownObject:IsOwnedByComboBox(self) then
-        self.m_dropdownObject:Refresh(item)
-    end
-
+b) Submenus do close upon selection of an entry (dropdownObject:Refresh isn't the reason, it only uses ZO_ScrollList_RefreshVisible(row))
 
 	---> It will be called from dropdownClass:OnEntryMouseUp, and then call the ZO_ComboBoxDropdown_Keyboard.OnEntrySelected -> ZO_ComboBox:SetSelected -> ZO_ComboBox:SelectItem -> then:
 	-----> If no multiselection is enabled: ZO_ComboBox_Base.SelectItem -> ZO_ComboBox_Base:ItemSelectedClickHelper(item, ignoreCallback) -> item.callback(comboBox, itemName, item, selectionChanged, oldItem) function

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -3122,9 +3122,10 @@ function dropdownClass:Show(comboBox, itemTable, minWidth, maxWidth, maxHeight, 
 
 	--Any options.maxDropdownWidth "fixed width" chosen?
 	local maxDropdownWidth = self.m_comboBox:GetMaxDropdownWidth() --todo 20250126 Do not use comboBox directly here as it will return nil! Why does this return nil for a submenu? It was setup in table submenuClass_exposedVariables to copy from owining menu to the submenu , if missing.
-	--If a maxWidth was set in the options then use that one, else use the auto-size of the longest entry
-	local totalDropDownWidth = (maxDropdownWidth ~= nil and maxDropdownWidth) or (maxDropdownWidth == nil and longestEntryTextWidth) or maxWidth
-	totalDropDownWidth = zo_clamp(totalDropDownWidth, minWidth, totalDropDownWidth)
+	--If a maxWidth was set in the options then use that one, else use the auto-size of the longest entry. If the auto-size of the longest entry is smaller than the maxWidth, then use that instead!
+	local totalDropDownWidth = (maxDropdownWidth ~= nil and maxDropdownWidth < longestEntryTextWidth and maxDropdownWidth) or (maxDropdownWidth == nil and longestEntryTextWidth) or maxWidth
+	--Check if a minWidth is > than totalDropDownWidth
+	local desiredWidth = zo_clamp(totalDropDownWidth, minWidth, totalDropDownWidth)
 
 --d(">[LSM]dropdownClass:Show - minWidth: " .. tos(minWidth) ..", maxDropdownWidth: " .. tos(maxDropdownWidth) ..", maxWidth: " .. tos(maxWidth) .. ", totalDropDownWidth: " .. tos(totalDropDownWidth) .. ", longestEntryTextWidth: " ..tos(longestEntryTextWidth))
 
@@ -3142,7 +3143,7 @@ function dropdownClass:Show(comboBox, itemTable, minWidth, maxWidth, maxHeight, 
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 76, tos(totalDropDownWidth), tos(allItemsHeight), tos(desiredHeight)) end
 
 	ZO_Scroll_SetUseFadeGradient(scrollControl, not self.owner.disableFadeGradient )
-	control:SetWidth(totalDropDownWidth)
+	control:SetWidth(desiredWidth)
 	control:SetHeight(desiredHeight)
 
 	ZO_ScrollList_SetHeight(scrollControl, desiredHeight)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -3123,11 +3123,11 @@ function dropdownClass:Show(comboBox, itemTable, minWidth, maxWidth, maxHeight, 
 	--Any options.maxDropdownWidth "fixed width" chosen?
 	local maxDropdownWidth = self.m_comboBox:GetMaxDropdownWidth() --todo 20250126 Do not use comboBox directly here as it will return nil! Why does this return nil for a submenu? It was setup in table submenuClass_exposedVariables to copy from owining menu to the submenu , if missing.
 	--If a maxWidth was set in the options then use that one, else use the auto-size of the longest entry. If the auto-size of the longest entry is smaller than the maxWidth, then use that instead!
-	local totalDropDownWidth = (maxDropdownWidth ~= nil and maxDropdownWidth < longestEntryTextWidth and maxDropdownWidth) or (maxDropdownWidth == nil and longestEntryTextWidth) or maxWidth
+	local totalDropDownWidth = (maxDropdownWidth ~= nil and maxDropdownWidth < longestEntryTextWidth and maxDropdownWidth) or longestEntryTextWidth or maxWidth
 	--Check if a minWidth is > than totalDropDownWidth
 	local desiredWidth = zo_clamp(totalDropDownWidth, minWidth, totalDropDownWidth)
 
---d(">[LSM]dropdownClass:Show - minWidth: " .. tos(minWidth) ..", maxDropdownWidth: " .. tos(maxDropdownWidth) ..", maxWidth: " .. tos(maxWidth) .. ", totalDropDownWidth: " .. tos(totalDropDownWidth) .. ", longestEntryTextWidth: " ..tos(longestEntryTextWidth))
+d(">[LSM]dropdownClass:Show - minWidth: " .. tos(minWidth) ..", maxDropdownWidth: " .. tos(maxDropdownWidth) ..", maxWidth: " .. tos(maxWidth) .. ", totalDropDownWidth: " .. tos(totalDropDownWidth) .. ", longestEntryTextWidth: " ..tos(longestEntryTextWidth) ..", desiredWidth: " .. tos(desiredWidth))
 
 	--maxHeight should have been defined before via self:UpdateHeight() -> Settings control:SetHeight() so self.m_height was set
 	local desiredHeight = maxHeight

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -142,9 +142,9 @@ local buttonGroupDefaultContextMenu
 --Menu settings (main and submenu) - default values
 local DEFAULT_VISIBLE_ROWS = 10
 local DEFAULT_SORTS_ENTRIES = false --sort the entries in main- and submenu lists (ZO_ComboBox default is true!)
-local DEFAULT_HEIGHT = 250
-local MIN_WIDTH_WITHOUT_HEADER = 50
-local MIN_WIDTH_WITH_SEARCH_HEADER = 150
+local DEFAULT_HEIGHT                  = 250
+local MIN_WIDTH_WITHOUT_SEARCH_HEADER = 50
+local MIN_WIDTH_WITH_SEARCH_HEADER    = 125
 
 --dropdown settings
 local SUBMENU_SHOW_TIMEOUT = 500 --350 ms before
@@ -406,7 +406,7 @@ local comboBoxDefaults = {
 	visibleRowsSubmenu = 			DEFAULT_VISIBLE_ROWS,
 	baseEntryHeight = 				ZO_COMBO_BOX_ENTRY_TEMPLATE_HEIGHT,
 	headerCollapsed = 				false,
-	containerMinWidth =				MIN_WIDTH_WITHOUT_HEADER,
+	containerMinWidth = MIN_WIDTH_WITHOUT_SEARCH_HEADER,
 }
 lib.comboBoxDefaults = comboBoxDefaults
 
@@ -991,10 +991,13 @@ do
 			headerControl:SetHeight(headerHeight)
 		end
 
-		if not collapsed and isFilterEnabled then
-			if headerControl:GetWidth() < MIN_WIDTH_WITH_SEARCH_HEADER then
-				headerControl:SetDimensionConstraints(MIN_WIDTH_WITH_SEARCH_HEADER, headerHeight)
-			end
+		local headerWidth = headerControl:GetWidth()
+		if isFilterEnabled and headerWidth < MIN_WIDTH_WITH_SEARCH_HEADER then
+			headerControl:SetDimensionConstraints(MIN_WIDTH_WITH_SEARCH_HEADER, headerHeight)
+			headerControl:SetWidth(MIN_WIDTH_WITH_SEARCH_HEADER)
+		elseif not isFilterEnabled and headerWidth < MIN_WIDTH_WITH_SEARCH_HEADER then
+			headerControl:SetDimensionConstraints(MIN_WIDTH_WITHOUT_SEARCH_HEADER, headerHeight)
+			headerControl:SetWidth(MIN_WIDTH_WITHOUT_SEARCH_HEADER)
 		end
 	end
 	
@@ -3915,10 +3918,10 @@ function comboBox_base:GetBaseWidth(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 91, tos(getControlName(control)), tos(control.header ~= nil), tos(control.header ~= nil and control.header:GetWidth() or 0)) end
 	if control and control.header then
 		local minWidth = control.header:GetWidth()
-		if minWidth <= 0 then minWidth = MIN_WIDTH_WITHOUT_HEADER end
+		if minWidth <= 0 then minWidth = MIN_WIDTH_WITHOUT_SEARCH_HEADER end
 		return minWidth
 	end
-	return MIN_WIDTH_WITHOUT_HEADER
+	return MIN_WIDTH_WITHOUT_SEARCH_HEADER
 end
 
 
@@ -4368,7 +4371,7 @@ function comboBox_base:UpdateWidth(control)
 	-->Will be overwritten at Show function IF no maxWidth is set and any entry in the list is wider (text width) than the container width
 	local maxDropdownWidth = self:GetMaxDropdownWidth()
 	local maxWidthInTotal = maxDropdownWidth or self.m_containerWidth
-	if maxWidthInTotal <= 0 then maxWidthInTotal = MIN_WIDTH_WITHOUT_HEADER end
+	if maxWidthInTotal <= 0 then maxWidthInTotal = MIN_WIDTH_WITHOUT_SEARCH_HEADER end
 
 	--Calculate end width
 	local newWidth = maxWidthInTotal
@@ -6042,11 +6045,11 @@ LibScrollableMenu = lib
 -------------------
 WORKING ON - Current version: 2.34 - Updated 2025-01-25
 -------------------
-1. Fix header with searchbox to have a minimum width (to show the search box and button properly)
-2. maxDropdownWidth option
---20250126 Working for main menu, but not submenus (contextmenus untested)! Submenus width is kind of 0 or at least no entries show. Search for GetMaxDropdownWidth and/or .m_containerMinWidth
-
 3. Support Multiselect properly
+
+Added:
+1. Fix header with searchbox to have a minimum width
+2. maxDropdownWidth option
 
 
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -3628,6 +3628,7 @@ function comboBox_base:Initialize(parent, comboBoxContainer, options, depth)
 
 	self:UpdateOptions(options, true)
 	self:SetupDropdownHeader()
+	self:UpdateWidth()
 	self:UpdateHeight()
 end
 
@@ -6047,9 +6048,11 @@ LibScrollableMenu = lib
 -------------------
 WORKING ON - Current version: 2.34 - Updated 2025-01-25
 -------------------
--Support Multiselect properly
--maxDropdownWidth option
--Fix header with searchbox to have a minimum width (to show the search box and button properly)
+1. Fix header with searchbox to have a minimum width (to show the search box and button properly)
+2. maxDropdownWidth option
+--20250126 Working for main menu, but not submenus (contextmenus untested)! Submenus width is kind of 0 or at least no entries show. Search for GetMaxDropdownWidth and/or .m_containerMaxWidth
+
+3. Support Multiselect properly
 
 
 

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -6082,7 +6082,12 @@ LibScrollableMenu = lib
 -------------------
 WORKING ON - Current version: 2.34 - Updated 2025-01-25
 -------------------
-3. Support Multiselect properly
+3. Support Multiselect properly (works at normal main menu)
+Bugs:
+--Initial text for noSelectionText is shown as default text of ZO_ComboBox and not updated from options properly
+--Submenus do close upon selection of an entry
+--Submenus do not show the selected highlight as they open again
+
 
 Added:
 1. Fix header with searchbox to have a minimum width

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.33
-## AddOnVersion: 020303
+## Version: 2.34
+## AddOnVersion: 020304
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101044 101045

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -23,4 +23,4 @@ LibScrollableMenu.xml
 ## Uncomment this to test the combobox with different menu entryTypes and submenus
 ## Use slash command /lsmtest to show the test UI
 ## Inspect the code in LSM_test.lua file to see how the API functions etc. work
-## LSM_test.lua
+LSM_test.lua

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,7 +1,8 @@
 -v- ---------------LSM v2.33 - 2025-01-26---------------------------------------------------------------------------- -v-
--Added: Fix header with searchbox to have a minimum width
--Added: maxDropdownWidth option
--Added: Support Multiselect properly
+-Bug fix #2501_1    Fix header with searchbox to have a minimum width
+-Added #2501_2      Added option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
+
+-Working on #2501_3 Support Multiselect properly
 
 
 -v- ---------------LSM v2.33 - 2025-01-01---------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,8 +1,14 @@
--v- ---------------LSM v2.33 - 2025-01-26---------------------------------------------------------------------------- -v-
--Bug fix #2501_1    Fix header with searchbox to have a minimum width
--Added #2501_2      Added option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
-
--Working on #2501_3 Support Multiselect properly
+-v- ---------------LSM v2.34 - 2025-02-04---------------------------------------------------------------------------- -v-
+-Added  option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
+-Bug fix Fix header with searchbox to have a minimum width
+-Bug fix Support Multiselect properly
+--Fixed submenu multiselection
+--Added  options.enableMultiSelect
+--Added  options.maxNumSelections
+--Added  options.maxNumSelectionsErrorText
+--Added  options.multiSelectionTextFormatter
+--Added  options.noSelectionText
+--Added  options.OnSelectionBlockedCallback
 
 
 -v- ---------------LSM v2.33 - 2025-01-01---------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,3 +1,9 @@
+-v- ---------------LSM v2.33 - 2025-01-26---------------------------------------------------------------------------- -v-
+-Added: Fix header with searchbox to have a minimum width
+-Added: maxDropdownWidth option
+-Added: Support Multiselect properly
+
+
 -v- ---------------LSM v2.33 - 2025-01-01---------------------------------------------------------------------------- -v-
 -Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 -Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
@@ -13,7 +19,6 @@
 -Added: return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
 -Renamed: API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
 -Renamed: self.optionsData at contextMenus was properly renamed to self.contextMenuOptions
-
 
 -v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-
 -[Additions]-

--- a/LibScrollableMenu/debug.lua
+++ b/LibScrollableMenu/debug.lua
@@ -126,7 +126,7 @@ local debugLogMessagePatterns = {
 	[72] = "dropdownClass:OnEntryMouseUp - contextMenuCallback!",
 	[73] = "dropdownClass:SelectItemByIndex - index: %s, ignoreCallback: %s",
 	[74] = "dropdownClass:RunItemCallback - item: %s, ignoreCallback: %s",
-	[75] = "dropdownClass:Show - comboBox: %s, minWidth: %s, maxHeight: %s, spacing: %s",
+	[75] = "dropdownClass:Show - comboBox: %s, minWidth: %s, maxWidth: %s, maxHeight: %s, spacing: %s",
 	[76] = ">totalDropDownWidth: %s, allItemsHeight: %s, desiredHeight: %s",
 	[77] = "dropdownClass:UpdateHeight",
 	[78] = "dropdownClass:OnShow",
@@ -229,6 +229,10 @@ local debugLogMessagePatterns = {
 	[175] = "ZO_Menu -> ShowMenu. Items#: %s, menuType:  %s",
 	[176] = "Debugging turned %s",
 	[177] = "Verbose debugging turned %s / Debugging: %s",
+	[178] = "dropdownClass:UpdateWidth",
+	[179] = "comboBox_base:GetMaxDropdownWidth - maxDropdownWidth: %s",
+	[180] = "comboBox_base:GetBaseWidth - control: %s, gotHeader: %s, width: %s",
+	[181] = "comboBox_base:UpdateWidth - control: %q, newWidth: %s, maxWidth: %s, maxDropdownWidth: %s, headerWidth: %s",
 }
 
 

--- a/LibScrollableMenu/debug.lua
+++ b/LibScrollableMenu/debug.lua
@@ -232,7 +232,7 @@ local debugLogMessagePatterns = {
 	[178] = "dropdownClass:UpdateWidth",
 	[179] = "comboBox_base:GetMaxDropdownWidth - maxDropdownWidth: %s",
 	[180] = "comboBox_base:GetBaseWidth - control: %s, gotHeader: %s, width: %s",
-	[181] = "comboBox_base:UpdateWidth - control: %q, newWidth: %s, maxWidth: %s, maxDropdownWidth: %s, headerWidth: %s",
+	[181] = "comboBox_base:UpdateWidth - control: %q, newWidth: %s, maxWidth: %s, maxDropdownWidth: %s, minWidth: %s",
 }
 
 


### PR DESCRIPTION
LSM v2.34 - 2025-02-04
-Added  option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
-Bug fix Fix header with searchbox to have a minimum width
-Bug fix Support Multiselect properly
--Fixed submenu multiselection
--Added  options.enableMultiSelect
--Added  options.maxNumSelections
--Added  options.maxNumSelectionsErrorText
--Added  options.multiSelectionTextFormatter
--Added  options.noSelectionText
--Added  options.OnSelectionBlockedCallback