### PR TITLE
Version 2 3 4

### DIFF
--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -2774,7 +2774,7 @@ local dropdownClass = ZO_ComboBoxDropdown_Keyboard:Subclass() --vanilla: XML ZO_
 -- dropdownClass:New(To simplify locating the beginning of the class
 function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 55, tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(depth)) end
-df(debugPrefix.."dropdownClass:Initialize - parent: %s, comboBoxContainer: %s, depth: %s", tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(depth))
+--df(debugPrefix.."dropdownClass:Initialize - parent: %s, comboBoxContainer: %s, depth: %s", tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(depth))
 	local dropdownControl = CreateControlFromVirtual(comboBoxContainer:GetName(), GuiRoot, "LibScrollableMenu_Dropdown_Template", depth)
 	ZO_ComboBoxDropdown_Keyboard.Initialize(self, dropdownControl)
 	dropdownControl.object = self
@@ -2825,7 +2825,7 @@ df(debugPrefix.."dropdownClass:Initialize - parent: %s, comboBoxContainer: %s, d
 	]]
 	-->!!! This will be the place where the function HighlightControl above calls the highlightTemplateOrFunction function !!!
 	scrollCtrl.highlightTemplateOrFunction = function(control)
-d(debugPrefix .. "scrollCtrl.highlightTemplateOrFunction - " .. tos(getControlName(control)))
+--d(debugPrefix .. "scrollCtrl.highlightTemplateOrFunction - " .. tos(getControlName(control)))
 		if selfVar.owner then
 			--return selfVar.owner:GetHighlightTemplate(control)
 			local XMLVirtualHighlightTemplateOfRow = selfVar.owner:GetHighlightTemplate(control)
@@ -2840,12 +2840,12 @@ d(debugPrefix .. "scrollCtrl.highlightTemplateOrFunction - " .. tos(getControlNa
 			]]
 			LSM_CheckIfAnimationControlNeedsXMLTemplateChange(control, XMLVirtualHighlightTemplateOfRow)
 
-d(">XMLVirtualHighlightTemplateOfRow: " .. tos(XMLVirtualHighlightTemplateOfRow))
+--d(">XMLVirtualHighlightTemplateOfRow: " .. tos(XMLVirtualHighlightTemplateOfRow))
 			-->function PlayAnimationOnControl will set control[defaultHighLightAnimationFieldName] = animationControl then
 			--->Also see function scrollCtrl.highlightCallback below
 			return XMLVirtualHighlightTemplateOfRow, defaultHighLightAnimationFieldName --"LSM_HighlightAnimation"
 		end
-d("<<defaultHighlightTemplate: " .. tos(defaultHighlightTemplate))
+--d("<<defaultHighlightTemplate: " .. tos(defaultHighlightTemplate))
 		return defaultHighlightTemplate, defaultHighLightAnimationFieldName --"ZO_SelectionHighlight", "LSM_HighlightAnimation"
 	end
 
@@ -2854,7 +2854,7 @@ d("<<defaultHighlightTemplate: " .. tos(defaultHighlightTemplate))
 	--highlight control, at this control, with the current one.
 	-->Will be set here and read in function scrollCtrl.highlightTemplateOrFunction above -> LSM_CheckIfAnimationControlNeedsXMLTemplateChange
 	scrollCtrl.highlightCallback = function(control, isHighlighting)
-d(debugPrefix .. "scrollCtrl.highlightCallback - " .. tos(isHighlighting))
+--d(debugPrefix .. "scrollCtrl.highlightCallback - " .. tos(isHighlighting))
 		if control ~= nil and isHighlighting == true then
 			if selfVar.owner then
 				local animationFieldName = control.highlightAnimationFieldName
@@ -2864,10 +2864,10 @@ d(debugPrefix .. "scrollCtrl.highlightCallback - " .. tos(isHighlighting))
 						animationFieldName = 	animationFieldName,
 						highlightXMLTemplate = 	selfVar.owner:GetHighlightTemplate(control)
 					}
-d(">control.LSM_rowHighlightData SET")
+--d(">control.LSM_rowHighlightData SET")
 				end
 			else
-d("<<<control.LSM_rowHighlightData DELETED")
+--d("<<<control.LSM_rowHighlightData DELETED")
 				control.LSM_rowHighlightData = nil
 			end
 		end
@@ -3071,7 +3071,7 @@ function dropdownClass:IsMouseOverOpeningControl()
 end
 
 function dropdownClass:OnMouseEnterEntry(control)
-d(debugPrefix .. "dropdownClass:OnMouseEnterEntry - name: " .. tos(getControlName(control)))
+--d(debugPrefix .. "dropdownClass:OnMouseEnterEntry - name: " .. tos(getControlName(control)))
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 68, tos(getControlName(control))) end
 	-- Added here for when mouse is moved from away from dropdowns over a row, it will know to close specific children
 	self:OnMouseExitTimeout(control)
@@ -3079,7 +3079,6 @@ d(debugPrefix .. "dropdownClass:OnMouseEnterEntry - name: " .. tos(getControlNam
 	local data = getControlData(control)
 	if data.enabled == true then
 		if not runHandler(self, handlerFunctions["onMouseEnter"], control, data) then
-d(">runhandler onMouseEnter!")
 			--Each entryType uses the default scrolltemplates.lua, function PlayAnimationOnControl via the zo_comboBoxDropdown_onMouseEnterEntry function call,
 			--which calls ZO_ScrollList_MouseEnter -> which calls HighlightControl -> Which calls self.highlightTemplateOrFunction(control) to get/create the
 			--highlight control, and assign the virtual XML template to it, and to set the highlight animation on the control.

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -2497,23 +2497,28 @@ end
 local has_submenu = true
 local no_submenu = false
 
+local function checkForMultiSelectEnabled(selfVar, control)
+	local isMultiSelectEnabled = (selfVar.owner and selfVar.owner.m_enableMultiSelect) or false
+	return (not isMultiSelectEnabled and not control.closeOnSelect) or false
+end
+
 local handlerFunctions  = {
-	--return false to run default ZO_ComboBox OnMouseEnter handler + tooltip / true to skip original ZO:ComboBox handler and only show tooltip
+	--return false to run default ZO_ComboBox OnMouseEnter handler + tooltip / true to skip original ZO_ComboBox handler and only show tooltip
 	["onMouseEnter"] = {
-		[LSM_ENTRY_TYPE_NORMAL] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_NORMAL] = function(selfVar, control, data, ...)
 			onMouseEnter(control, data, no_submenu)
 			clearNewStatus(control, data)
-			return not control.closeOnSelect
+			return checkForMultiSelectEnabled(selfVar, control)
 		end,
-		[LSM_ENTRY_TYPE_HEADER] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_HEADER] = function(selfVar, control, data, ...)
 			-- Return true to skip the default handler to prevent row highlight.
 			return true
 		end,
-		[LSM_ENTRY_TYPE_DIVIDER] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_DIVIDER] = function(selfVar, control, data, ...)
 			-- Return true to skip the default handler to prevent row highlight.
 			return true
 		end,
-		[LSM_ENTRY_TYPE_SUBMENU] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_SUBMENU] = function(selfVar, control, data, ...)
 			--d( debugPrefix .. 'onMouseEnter [LSM_ENTRY_TYPE_SUBMENU]')
 			local dropdown = onMouseEnter(control, data, has_submenu)
 			clearTimeout()
@@ -2521,15 +2526,15 @@ local handlerFunctions  = {
 			dropdown:ShowSubmenu(control)
 			return false --not control.closeOnSelect
 		end,
-		[LSM_ENTRY_TYPE_CHECKBOX] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_CHECKBOX] = function(selfVar, control, data, ...)
 			onMouseEnter(control, data, no_submenu)
 			return false --not control.closeOnSelect
 		end,
-		[LSM_ENTRY_TYPE_BUTTON] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_BUTTON] = function(selfVar, control, data, ...)
 			onMouseEnter(control, data, no_submenu)
 			return false --not control.closeOnSelect
 		end,
-		[LSM_ENTRY_TYPE_RADIOBUTTON] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_RADIOBUTTON] = function(selfVar, control, data, ...)
 			onMouseEnter(control, data, no_submenu)
 			return false --not control.closeOnSelect
 		end,
@@ -2537,34 +2542,34 @@ local handlerFunctions  = {
 
 	--return false to run default ZO_ComboBox OnMouseEnter handler + tooltip / true to skip original ZO:ComboBox handler and only show tooltip
 	["onMouseExit"] = {
-		[LSM_ENTRY_TYPE_NORMAL] = function(control, data)
+		[LSM_ENTRY_TYPE_NORMAL] = function(selfVar, control, data)
 			onMouseExit(control, data, no_submenu)
-			return not control.closeOnSelect
+			return checkForMultiSelectEnabled(selfVar, control)
 		end,
-		[LSM_ENTRY_TYPE_HEADER] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_HEADER] = function(selfVar, control, data, ...)
 			-- Return true to skip the default handler to prevent row highlight.
 			return true
 		end,
-		[LSM_ENTRY_TYPE_DIVIDER] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_DIVIDER] = function(selfVar, control, data, ...)
 			-- Return true to skip the default handler to prevent row highlight.
 			return true
 		end,
-		[LSM_ENTRY_TYPE_SUBMENU] = function(control, data)
+		[LSM_ENTRY_TYPE_SUBMENU] = function(selfVar, control, data)
 			local dropdown = onMouseExit(control, data, has_submenu)
 			if not (MouseIsOver(control) or dropdown:IsEnteringSubmenu()) then
 				dropdown:OnMouseExitTimeout(control)
 			end
 			return false --not control.closeOnSelect
 		end,
-		[LSM_ENTRY_TYPE_CHECKBOX] = function(control, data)
+		[LSM_ENTRY_TYPE_CHECKBOX] = function(selfVar, control, data)
 			onMouseExit(control, data, no_submenu)
 			return false --not control.closeOnSelect
 		end,
-		[LSM_ENTRY_TYPE_BUTTON] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_BUTTON] = function(selfVar, control, data, ...)
 			onMouseExit(control, data, no_submenu)
 			return false --not control.closeOnSelect
 		end,
-		[LSM_ENTRY_TYPE_RADIOBUTTON] = function(control, data, ...)
+		[LSM_ENTRY_TYPE_RADIOBUTTON] = function(selfVar, control, data, ...)
 			onMouseExit(control, data, no_submenu)
 			return false --not control.closeOnSelect
 		end,
@@ -2581,42 +2586,42 @@ local handlerFunctions  = {
 
 	-- return true to "select" entry via described way in ZO_ComboBox handler (see above) / return false to "skip selection" and just run a callback function via dropdownClass:RunItemCallback
 	["onMouseUp"] = {
-		[LSM_ENTRY_TYPE_NORMAL] = function(control, data, button, upInside, ctrl, alt, shift)
+		[LSM_ENTRY_TYPE_NORMAL] = function(selfVar, control, data, button, upInside, ctrl, alt, shift)
 --d(debugPrefix .. 'onMouseUp [LSM_ENTRY_TYPE_NORMAL]')
 			onMouseUp(control, data, no_submenu)
 			return true
 		end,
-		[LSM_ENTRY_TYPE_HEADER] = function(control, data, button, upInside, ctrl, alt, shift)
+		[LSM_ENTRY_TYPE_HEADER] = function(selfVar, control, data, button, upInside, ctrl, alt, shift)
 			return false
 		end,
-		[LSM_ENTRY_TYPE_DIVIDER] = function(control, data, button, upInside, ctrl, alt, shift)
+		[LSM_ENTRY_TYPE_DIVIDER] = function(selfVar, control, data, button, upInside, ctrl, alt, shift)
 			return false
 		end,
-		[LSM_ENTRY_TYPE_SUBMENU] = function(control, data, button, upInside, ctrl, alt, shift)
+		[LSM_ENTRY_TYPE_SUBMENU] = function(selfVar, control, data, button, upInside, ctrl, alt, shift)
 --d(debugPrefix .. 'onMouseUp [LSM_ENTRY_TYPE_SUBMENU]')
 			onMouseUp(control, data, has_submenu)
 			return control.closeOnSelect --if submenu entry has data.callback then select the entry
 		end,
-		[LSM_ENTRY_TYPE_CHECKBOX] = function(control, data, button, upInside, ctrl, alt, shift)
+		[LSM_ENTRY_TYPE_CHECKBOX] = function(selfVar, control, data, button, upInside, ctrl, alt, shift)
 			onMouseUp(control, data, no_submenu)
 			return false
 		end,
-		[LSM_ENTRY_TYPE_BUTTON] = function(control, data, button, upInside, ctrl, alt, shift)
+		[LSM_ENTRY_TYPE_BUTTON] = function(selfVar, control, data, button, upInside, ctrl, alt, shift)
 			onMouseUp(control, data, no_submenu)
 			return false
 		end,
-		[LSM_ENTRY_TYPE_RADIOBUTTON] = function(control, data, button, upInside, ctrl, alt, shift)
+		[LSM_ENTRY_TYPE_RADIOBUTTON] = function(selfVar, control, data, button, upInside, ctrl, alt, shift)
 			onMouseUp(control, data, no_submenu)
 			return false
 		end,
 	},
 }
 
-local function runHandler(handlerTable, control, ...)
+local function runHandler(selfVar, handlerTable, control, ...)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 53, tos(getControlName(control)), tos(handlerTable), tos(control.typeId)) end
 	local handler = handlerTable[control.typeId]
 	if handler then
-		return handler(control, ...)
+		return handler(selfVar, control, ...)
 	end
 	return false
 end
@@ -2769,7 +2774,7 @@ local dropdownClass = ZO_ComboBoxDropdown_Keyboard:Subclass() --vanilla: XML ZO_
 -- dropdownClass:New(To simplify locating the beginning of the class
 function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 55, tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(depth)) end
-	--df(debugPrefix.."dropdownClass:Initialize - parent: %s, comboBoxContainer: %s, depth: %s", tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(depth))
+df(debugPrefix.."dropdownClass:Initialize - parent: %s, comboBoxContainer: %s, depth: %s", tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(depth))
 	local dropdownControl = CreateControlFromVirtual(comboBoxContainer:GetName(), GuiRoot, "LibScrollableMenu_Dropdown_Template", depth)
 	ZO_ComboBoxDropdown_Keyboard.Initialize(self, dropdownControl)
 	dropdownControl.object = self
@@ -2820,7 +2825,7 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	]]
 	-->!!! This will be the place where the function HighlightControl above calls the highlightTemplateOrFunction function !!!
 	scrollCtrl.highlightTemplateOrFunction = function(control)
---d(debugPrefix .. "scrollCtrl.highlightTemplateOrFunction - " .. tos(getControlName(control)))
+d(debugPrefix .. "scrollCtrl.highlightTemplateOrFunction - " .. tos(getControlName(control)))
 		if selfVar.owner then
 			--return selfVar.owner:GetHighlightTemplate(control)
 			local XMLVirtualHighlightTemplateOfRow = selfVar.owner:GetHighlightTemplate(control)
@@ -2835,10 +2840,12 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 			]]
 			LSM_CheckIfAnimationControlNeedsXMLTemplateChange(control, XMLVirtualHighlightTemplateOfRow)
 
+d(">XMLVirtualHighlightTemplateOfRow: " .. tos(XMLVirtualHighlightTemplateOfRow))
 			-->function PlayAnimationOnControl will set control[defaultHighLightAnimationFieldName] = animationControl then
 			--->Also see function scrollCtrl.highlightCallback below
 			return XMLVirtualHighlightTemplateOfRow, defaultHighLightAnimationFieldName --"LSM_HighlightAnimation"
 		end
+d("<<defaultHighlightTemplate: " .. tos(defaultHighlightTemplate))
 		return defaultHighlightTemplate, defaultHighLightAnimationFieldName --"ZO_SelectionHighlight", "LSM_HighlightAnimation"
 	end
 
@@ -2847,6 +2854,7 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 	--highlight control, at this control, with the current one.
 	-->Will be set here and read in function scrollCtrl.highlightTemplateOrFunction above -> LSM_CheckIfAnimationControlNeedsXMLTemplateChange
 	scrollCtrl.highlightCallback = function(control, isHighlighting)
+d(debugPrefix .. "scrollCtrl.highlightCallback - " .. tos(isHighlighting))
 		if control ~= nil and isHighlighting == true then
 			if selfVar.owner then
 				local animationFieldName = control.highlightAnimationFieldName
@@ -2856,8 +2864,10 @@ function dropdownClass:Initialize(parent, comboBoxContainer, depth)
 						animationFieldName = 	animationFieldName,
 						highlightXMLTemplate = 	selfVar.owner:GetHighlightTemplate(control)
 					}
+d(">control.LSM_rowHighlightData SET")
 				end
 			else
+d("<<<control.LSM_rowHighlightData DELETED")
 				control.LSM_rowHighlightData = nil
 			end
 		end
@@ -3061,17 +3071,19 @@ function dropdownClass:IsMouseOverOpeningControl()
 end
 
 function dropdownClass:OnMouseEnterEntry(control)
---d(debugPrefix .. "dropdownClass:OnMouseEnterEntry - name: " .. tos(getControlName(control)))
+d(debugPrefix .. "dropdownClass:OnMouseEnterEntry - name: " .. tos(getControlName(control)))
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 68, tos(getControlName(control))) end
 	-- Added here for when mouse is moved from away from dropdowns over a row, it will know to close specific children
 	self:OnMouseExitTimeout(control)
 
 	local data = getControlData(control)
 	if data.enabled == true then
-		if not runHandler(handlerFunctions["onMouseEnter"], control, data) then
-			--Each entryType uses the default scrolltemplates.lua, function PlayAnimationOnControl via the zo_comboBoxDropdown_onMouseEnterEntry function call
-			--to get/create the highlight control and assign the virtual XML tempalte to it, and to set the highlight animation on the control.
-			--> See function dropdownClass:Initialize -> function scrollCtrl.highlightTemplateOrFunction and function scrollCtrl.highlightCallback
+		if not runHandler(self, handlerFunctions["onMouseEnter"], control, data) then
+d(">runhandler onMouseEnter!")
+			--Each entryType uses the default scrolltemplates.lua, function PlayAnimationOnControl via the zo_comboBoxDropdown_onMouseEnterEntry function call,
+			--which calls ZO_ScrollList_MouseEnter -> which calls HighlightControl -> Which calls self.highlightTemplateOrFunction(control) to get/create the
+			--highlight control, and assign the virtual XML template to it, and to set the highlight animation on the control.
+			--> See function dropdownClass:Initialize -> function scrollCtrl.highlightTemplateOrFunction and function scrollCtrl.highlightCallback here in LSM
 			zo_comboBoxDropdown_onMouseEnterEntry(self, control)
 		end
 
@@ -3094,7 +3106,7 @@ function dropdownClass:OnMouseExitEntry(control)
 	hideTooltip(control)
 	local data = getControlData(control)
 	self:OnMouseExitTimeout(control)
-	if data.enabled and not runHandler(handlerFunctions["onMouseExit"], control, data) then
+	if data.enabled and not runHandler(self, handlerFunctions["onMouseExit"], control, data) then
 		zo_comboBoxDropdown_onMouseExitEntry(self, control)
 	end
 
@@ -3160,7 +3172,7 @@ LSM_Debug = {
 				end
 --d(debugPrefix .. "OnEntryMouseUp-multiSelection: " ..tos(isMultiSelectionEnabled) .."/" .. tos(isMultiSelectionEnabledAtParentMenu) .. ", isSubmenu: " .. tos(comboBox.isSubmenu))
 
-				if not ignoreHandler and runHandler(handlerFunctions["onMouseUp"], control, data, button, upInside, ctrl, alt, shift) then
+				if not ignoreHandler and runHandler(self, handlerFunctions["onMouseUp"], control, data, button, upInside, ctrl, alt, shift) then
 					self:OnEntrySelected(control) --self (= dropdown).owner (= combobox):SetSelected -> self.SelectItem
 				else
 					self:RunItemCallback(data, data.ignoreCallback)

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1008,8 +1008,11 @@ do
 		g_currentBottomLeftHeader = controlId
 
 		local height = control:GetHeight()
+
+--d(">header_applyAnchorSetToControl-controlId: " .. tos(controlId) .. ", heightOfCtrl: " .. tos(height) .. ", controlName: " ..getControlName(control))
+
 		if controlId == TOGGLE_BUTTON then
-			-- We want to keep height if collapsed but not add height for the button if not.
+			-- We want to keep height if collapsed, but not add height for the button if not collapsed.
 			height = collapsed and height or 0
 		--The control processed is the collapsed header's toggle button "click extension"
 		elseif controlId == TOGGLE_BUTTON_CLICK_EXTENSION then
@@ -1025,7 +1028,6 @@ do
 				control:SetDimensions(0, 0)
 			end
 		end
-
 		return height
 	end
 
@@ -1037,6 +1039,7 @@ do
 	end
 	
 	local function header_updateAnchors(headerControl, refreshResults, collapsed, isFilterEnabled)
+--d(debugPrefix .. "header_updateAnchors - collapsed: " ..tos(collapsed) .. "; isFilterEnabled: " ..tos(isFilterEnabled))
 		--local headerHeight = collapsed and 0 or 17
 		local headerHeight = 0
 		local controls = headerControl.controls
@@ -1063,6 +1066,7 @@ do
 			end
 		end
 
+--d(">headerHeight: " ..tos(headerHeight))
 		if headerHeight > 0 then
 			if not collapsed then
 				headerHeight = headerHeight + (ROW_OFFSET_Y * 3)
@@ -1147,6 +1151,8 @@ do
 	end
 
 	refreshDropdownHeader = function(comboBox, headerControl, options, collapsed)
+--d(debugPrefix .. "refreshDropdownHeader - collapsed: " ..tos(collapsed))
+
 		local controls = headerControl.controls
 
 		headerControl:SetHidden(true)
@@ -1170,6 +1176,7 @@ do
 		refreshResults[TOGGLE_BUTTON] = header_processData(controls[TOGGLE_BUTTON], getValueOrCallback(options.headerCollapsible, options))
 		refreshResults[TOGGLE_BUTTON_CLICK_EXTENSION] = header_processData(controls[TOGGLE_BUTTON_CLICK_EXTENSION], getValueOrCallback(options.headerCollapsible, options))
 
+		headerControl:SetDimensionConstraints(MIN_WIDTH_WITHOUT_SEARCH_HEADER, 0)
 		header_updateAnchors(headerControl, refreshResults, collapsed, isFilterEnabled)
 	end
 end
@@ -4491,6 +4498,7 @@ function comboBox_base:UpdateHeight(control)
 	local headerHeight = 0
 	if control ~= nil then
 		headerHeight = self:GetBaseHeight(control)
+--d(">>header BaseHeight: " ..tos(headerHeight))
 	end
 
 	--Calculate the maximum height now:
@@ -4503,7 +4511,7 @@ function comboBox_base:UpdateHeight(control)
 		-- Add spacing to each row then subtract spacing for last row
 		maxHeightByEntries = ((baseEntryHeight + spacing) * maxRows) - spacing + (ZO_SCROLLABLE_COMBO_BOX_LIST_PADDING_Y * 2)
 
---d(">[LSM]maxRows: " ..tos(maxRows) .. ", maxHeightByEntries: " ..tos(maxHeightByEntries))
+--d(">>maxRows: " ..tos(maxRows) .. ", maxHeightByEntries: " ..tos(maxHeightByEntries))
 		--Add the header's height first, then add the rows' calculated needed total height
 		maxHeightInTotal = maxHeightByEntries
 	end
@@ -4521,7 +4529,7 @@ function comboBox_base:UpdateHeight(control)
 	--maxHeightInTotal = (maxHeightInTotal > screensMaxDropdownHeight and screensMaxDropdownHeight) or maxHeightInTotal
 	--If the height of the total height is below minHeight then increase it to be at least that high
 	maxHeightInTotal = zo_clamp(maxHeightInTotal, minHeight, screensMaxDropdownHeight)
---d(">[LSM]headerHeight: " ..tos(headerHeight) .. ", maxHeightInTotal: " ..tos(maxHeightInTotal))
+--d(">>>headerHeight: " ..tos(headerHeight) .. ", maxHeightInTotal: " ..tos(maxHeightInTotal))
 
 
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 107, tos(getControlName(control)), tos(maxHeightInTotal), tos(maxDropdownHeight), tos(maxHeightByEntries),  tos(baseEntryHeight), tos(maxRows), tos(spacing), tos(headerHeight)) end
@@ -5230,6 +5238,9 @@ end
 --Toggle function called as the collapsible header is clicked
 function comboBoxClass:UpdateDropdownHeader(toggleButtonCtrl)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 139, tos(self.options), tos(toggleButtonCtrl)) end
+
+--d(debugPrefix .. "comboBoxClass:UpdateDropdownHeader")
+
 	local headerControl, dropdownControl = getHeaderControl(self)
 	if headerControl == nil then return end
 
@@ -5242,16 +5253,19 @@ function comboBoxClass:UpdateDropdownHeader(toggleButtonCtrl)
 			headerCollapsed = ZO_CheckButton_IsChecked(toggleButtonCtrl)
 
 			if options.headerCollapsed == nil then
+--d(">updateSavedVariable collapsedHeaderState: " ..tos(getHeaderToggleStateControlSavedVariableName(self)))
 				-- No need in saving state if we are going to force state by options.headerCollapsed
 				updateSavedVariable("collapsedHeaderState", headerCollapsed, getHeaderToggleStateControlSavedVariableName(self))
 			end
 		end
 	end
+--d(">headerCollapsed: " ..tos(headerCollapsed))
 
 	--d(debugPrefix.."comboBoxClass:UpdateDropdownHeader - headerCollapsed: " ..tos(headerCollapsed))
 	refreshDropdownHeader(self, headerControl, self.options, headerCollapsed)
 	self:UpdateWidth(dropdownControl) --> Update self.m_containerWidth properly for self:Show (in self:UpdateHeight) call (including the now, in refreshDropdownHeader, updated header's width)
 	self:UpdateHeight(dropdownControl) --> Update self.m_height properly for self:Show call (including the now, in refreshDropdownHeader, updated header's height)
+--d(">new height: " ..tos(self.m_height))
 end
 
 --------------------------------------------------------------------


### PR DESCRIPTION
Several fixes for existing ZO_ComboBoxes where API function AddCustomScrollableComboBoxDropdownMenu is used to apply LSM to them
-> Multiselection, Row highlights, options passed in, options changed at the original ZO_ComboBox which got overwritten by LSM defaults (e.g. before enabled multiselectiomn -> disabled by default via LSM then), etc.