### PR TITLE
Version 2 3 4

### DIFF
--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -1898,7 +1898,7 @@ local function checkIfHiddenForReasons(selfVar, button, isContextMenu, owningWin
 	local contextMenuDropdownObject = g_contextMenu.m_dropdownObject
 	local isOwnedByComboBox = dropdownObject:IsOwnedByComboBox(comboBox)
 	local isCntxtMenOwnedByComboBox = contextMenuDropdownObject:IsOwnedByComboBox(comboBox)
---d(">isOwnedByCBox: " .. tos(isOwnedByComboBox) .. ", isCntxtMenVis: " .. tos(isContextMenuVisible) .. ", isCntxtMenOwnedByCBox: " ..tos(isCntxtMenOwnedByComboBox) .. ", isSubmenu: " .. tos(selfVar.isSubmenu))
+d("[checkIfHiddenForReasons]isOwnedByCBox: " .. tos(isOwnedByComboBox) .. ", isCntxtMenVis: " .. tos(isContextMenuVisible) .. ", isCntxtMenOwnedByCBox: " ..tos(isCntxtMenOwnedByComboBox) .. ", isSubmenu: " .. tos(selfVar.isSubmenu))
 
 
 	if not isContextMenu then
@@ -2014,6 +2014,7 @@ local function checkIfHiddenForReasons(selfVar, button, isContextMenu, owningWin
 			if mocCtrl and mocCtrl.closeOnSelect == false then
 				doNotHideContextMenu = true
 				suppressNextOnGlobalMouseUp = true
+--d(">suppressNextOnGlobalMouseUp: " ..tos(suppressNextOnGlobalMouseUp))
 				returnValue = false
 			end
 
@@ -3170,6 +3171,7 @@ LSM_Debug = {
 			if button == MOUSE_BUTTON_INDEX_LEFT then
 				if checkIfContextMenuOpenedButOtherControlWasClicked(control, comboBox, button) == true then
 					suppressNextOnGlobalMouseUp = true
+--d("[dropdownClass:OnEntryMouseUp]MOUSE_BUTTON_INDEX_LEFT -> suppressNextOnGlobalMouseUp: " ..tos(suppressNextOnGlobalMouseUp))
 					return
 				end
 
@@ -3550,6 +3552,7 @@ function dropdownClass:ShowFilterEditBoxHistory(filterBox)
 
 			--Prevent LSM Hook at ShowMenu() to close the LSM below the cursor!!!
 			lib.preventLSMClosingZO_Menu = true
+--d(">preventLSMClosingZO_Menu: " ..tos(lib.preventLSMClosingZO_Menu))
 			ShowMenu(filterBox)
 			ZO_Tooltips_HideTextTooltip()
 		end
@@ -4093,7 +4096,7 @@ end
 --Called from ZO_ComboBox:ShowDropdownInternal() -> self.m_container:RegisterForEvent(EVENT_GLOBAL_MOUSE_UP, function(...) self:OnGlobalMouseUp(...) end)
 function comboBox_base:OnGlobalMouseUp(eventId, button)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 90, tos(button), tos(suppressNextOnGlobalMouseUp)) end
---d("comboBox_base:OnGlobalMouseUp-button: " ..tos(button) .. ", suppressNextMouseUp: " .. tos(suppressNextOnGlobalMouseUp))
+--d(debugPrefix .. "comboBox_base:OnGlobalMouseUp-button: " ..tos(button) .. ", suppressNextMouseUp: " .. tos(suppressNextOnGlobalMouseUp))
 	if suppressNextOnGlobalMouseUp then
 		suppressNextOnGlobalMouseUp = nil
 		return false
@@ -6276,6 +6279,7 @@ local function onAddonLoaded(event, name)
 		--Should the ZO_Menu not close any opened LSM? e.g. to show the textSearchHistory at the LSM text filter search box
 		if lib.preventLSMClosingZO_Menu then
 			lib.preventLSMClosingZO_Menu = nil
+--d("[ShowMenu]preventLSMClosingZO_Menu: " ..tos(lib.preventLSMClosingZO_Menu))
 			return
 		end
 		hideCurrentlyOpenedLSMAndContextMenu()
@@ -6359,6 +6363,7 @@ TODO - To check (future versions)
 	2. Attention: zo_comboBox_base_hideDropdown(self) in self:HideDropdown() does NOT close the main dropdown if right clicked! Only for a left click... See ZO_ComboBox:HideDropdownInternal()
 	3. verify submenu anchors. Small adjustments not easily seen on small laptop monitor
 	- fired on handlers dropdown_OnShow dropdown_OnHide
+	4. If header is enabled and the filter is enabled, you right clicked the editbox of the filter header, and choose an entry: Next left click outside does not close the opened dropdown)
 
 ---------------------------------------------------------------
 UPCOMING FEATURES  - What could be added in the future?

--- a/LibScrollableMenu/LibScrollableMenu.lua
+++ b/LibScrollableMenu/LibScrollableMenu.lua
@@ -2122,7 +2122,7 @@ local function clearNewStatus(control, data)
 			lib:FireCallbacks('NewStatusUpdated', control, data)
 			if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG_CALLBACK, 33, tos(getControlName(control))) end
 
-d(debugPrefix.."clearNewStatus - " .. tos(getControlName(control)))
+--d(debugPrefix.."clearNewStatus - " .. tos(getControlName(control)))
 			control.m_dropdownObject:Refresh(data)
 			
 			local parent = data.m_parentControl

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -23,4 +23,4 @@ LibScrollableMenu.xml
 ## Uncomment this to test the combobox with different menu entryTypes and submenus
 ## Use slash command /lsmtest to show the test UI
 ## Inspect the code in LSM_test.lua file to see how the API functions etc. work
-LSM_test.lua
+## LSM_test.lua

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,4 +1,4 @@
--v- ---------------LSM v2.34 - 2025-02-04---------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.34 - 2025-02-07---------------------------------------------------------------------------- -v-
 -Added  option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
 -Bug fix Fix header with searchbox to have a minimum width
 -Bug fix Support Multiselect properly


### PR DESCRIPTION
-v- ---------------LSM v2.34 - 2025-02-07---------------------------------------------------------------------------- -v-
-Added  option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
-Bug fix Fix header with searchbox to have a minimum width
-Bug fix Support Multiselect properly
--Fixed submenu multiselection
--Added  options.enableMultiSelect
--Added  options.maxNumSelections
--Added  options.maxNumSelectionsErrorText
--Added  options.multiSelectionTextFormatter
--Added  options.noSelectionText
--Added  options.OnSelectionBlockedCallback