### PR TITLE
LSM v2.34

### DIFF
--- a/LibScrollableMenu/LSM_test.lua
+++ b/LibScrollableMenu/LSM_test.lua
@@ -95,9 +95,17 @@ local function test()
 		-- Options for the main combobox menu
 		--==============================================================================================================
 		local options = {
+			enableMultiSelect = true, --todo 20250127 test
+			maxNumSelections = 2,
+			maxNumSelectionsErrorText =		debugPrefix.."ERROR - Maximum items selected already",
+			multiSelectionTextFormatter = 	"<<1>> selected",
+			noSelectionText = 				"",
+			OnSelectionBlockedCallback = function() d(debugPrefix.."ERROR - Selection of entry was blocked!") end,
+
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,
 			maxDropdownHeight = 450,
+			--maxDropdownWidth = 450,
 
 			--Big yellow headers!
 			--headerFont = "ZoFontHeader3",

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.33
-## AddOnVersion: 020303
+## Version: 2.34
+## AddOnVersion: 020304
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101044 101045

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,3 +1,16 @@
+-v- ---------------LSM v2.34 - 2025-02-07---------------------------------------------------------------------------- -v-
+-Added  option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width
+-Bug fix Fix header with searchbox to have a minimum width
+-Bug fix Support Multiselect properly
+--Fixed submenu multiselection
+--Added  options.enableMultiSelect
+--Added  options.maxNumSelections
+--Added  options.maxNumSelectionsErrorText
+--Added  options.multiSelectionTextFormatter
+--Added  options.noSelectionText
+--Added  options.OnSelectionBlockedCallback
+
+
 -v- ---------------LSM v2.33 - 2025-01-01---------------------------------------------------------------------------- -v-
 -Bug fix: Submenu options applied again via API function SetCustomScrollableMenuOptions did not apply (visibleRowsSubmenu e.g.)
 -Bug fix: Name of handler for context menu show and hide changed to proper Uppercase OnContextMenu*
@@ -13,7 +26,6 @@
 -Added: return values index/indices, entryData/entryDataTable to the context menu API functions AddCustomScrollableMenuEntry/Entries etc.
 -Renamed: API function lib.SetButtonGroupState to lib.ButtonGroupDefaultContextMenu as the name was missleading. It never changed or set any values directly it only added a contextmenu where you could choose "Select all", "Select none", "Invers"
 -Renamed: self.optionsData at contextMenus was properly renamed to self.contextMenuOptions
-
 
 -v- ---------------LSM v2.32 - 2024-10-19---------------------------------------------------------------------------- -v-
 -[Additions]-

--- a/LibScrollableMenu/debug.lua
+++ b/LibScrollableMenu/debug.lua
@@ -126,7 +126,7 @@ local debugLogMessagePatterns = {
 	[72] = "dropdownClass:OnEntryMouseUp - contextMenuCallback!",
 	[73] = "dropdownClass:SelectItemByIndex - index: %s, ignoreCallback: %s",
 	[74] = "dropdownClass:RunItemCallback - item: %s, ignoreCallback: %s",
-	[75] = "dropdownClass:Show - comboBox: %s, minWidth: %s, maxHeight: %s, spacing: %s",
+	[75] = "dropdownClass:Show - comboBox: %s, minWidth: %s, maxWidth: %s, maxHeight: %s, spacing: %s",
 	[76] = ">totalDropDownWidth: %s, allItemsHeight: %s, desiredHeight: %s",
 	[77] = "dropdownClass:UpdateHeight",
 	[78] = "dropdownClass:OnShow",
@@ -229,6 +229,10 @@ local debugLogMessagePatterns = {
 	[175] = "ZO_Menu -> ShowMenu. Items#: %s, menuType:  %s",
 	[176] = "Debugging turned %s",
 	[177] = "Verbose debugging turned %s / Debugging: %s",
+	[178] = "dropdownClass:UpdateWidth",
+	[179] = "comboBox_base:GetMaxDropdownWidth - maxDropdownWidth: %s",
+	[180] = "comboBox_base:GetBaseWidth - control: %s, gotHeader: %s, width: %s",
+	[181] = "comboBox_base:UpdateWidth - control: %q, newWidth: %s, maxWidth: %s, maxDropdownWidth: %s, minWidth: %s",
 }
 
 


### PR DESCRIPTION
…------------------------------------------------ -v-

-Added  option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width -Bug fix Fix header with searchbox to have a minimum width -Bug fix Support Multiselect properly
--Fixed submenu multiselection
--Added  options.enableMultiSelect
--Added  options.maxNumSelections
--Added  options.maxNumSelectionsErrorText
--Added  options.multiSelectionTextFormatter
--Added  options.noSelectionText
--Added  options.OnSelectionBlockedCallback