### PR TITLE
Version 2 3 6

### DIFF
--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -98,6 +98,7 @@ end
 --		number visibleRowsSubmenu:optional		Number or function returning number of shown entries at 1 page of the scrollable comboBox's opened submenus
 --		number maxDropdownHeight				Number or function returning number of total dropdown's maximum height
 --		number maxDropdownWidth					Number or function returning number of total dropdown's maximum width
+--		number minDropdownWidth					Number or function returning number of total dropdown's minimum width
 --		boolean sortEntries:optional			Boolean or function returning boolean if items in the main-/submenu should be sorted alphabetically. !!!Attention: Default is TRUE (sorting is enabled)!!!
 --		table sortType:optional					table or function returning table for the sort type, e.g. ZO_SORT_BY_NAME, ZO_SORT_BY_NAME_NUMERIC
 --		boolean sortOrder:optional				Boolean or function returning boolean for the sort order ZO_SORT_ORDER_UP or ZO_SORT_ORDER_DOWN

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -110,6 +110,7 @@ end
 --		table normalColor:optional				table (ZO_ColorDef) or function returning a color table with r, g, b, a keys and their values: for all normal (enabled) entries
 --		table disabledColor:optional 			table (ZO_ColorDef) or function returning a color table with r, g, b, a keys and their values: for all disabled entries
 --		table submenuArrowColor:optional		table (ZO_ColorDef) or function returning a color table with r, g, b, a keys and their values: for the submenu opening arrow > texture
+--		string submenuOpenToSide				String or function returning a string "left" or "right": Force the submenu to open at the left/right side. If not specififed the submenu opens at the side where there is enough space to show the whole menu (GUI root/screen size is respected)
 --		boolean highlightContextMenuOpeningControl Boolean or function returning boolean if the openingControl of a context menu should be highlighted.
 --												If you set this to true you either also need to set data.m_highlightTemplate at the row and provide the XML template name for the highLight, e.g. "LibScrollableMenu_Highlight_Green".
 --												Or (if not at contextMenu options!!!) you can use the templateContextMenuOpeningControl at options.XMLRowHighlightTemplates[lib.scrollListRowTypes.LSM_ENTRY_TYPE_*] = { template = "ZO_SelectionHighlight" , templateContextMenuOpeningControl = "LibScrollableMenu_Highlight_Green" } to specify the XML highlight template for that entryType

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -338,9 +338,9 @@ local addCustomScrollableMenuEntry = AddCustomScrollableMenuEntry
 --> See examples for the table "entries" values above AddCustomScrollableMenuEntry
 --Existing context menu entries will be kept (until ClearCustomScrollableMenu will be called)
 ---> returns nilable:number indexOfNewAddedEntry, nilable:table newEntryData
-function AddCustomScrollableSubMenuEntry(text, entries)
+function AddCustomScrollableSubMenuEntry(text, entries, callbackFunc)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 163, tos(text), tos(entries)) end
-	return addCustomScrollableMenuEntry(text, nil, entryTypeConstants.LSM_ENTRY_TYPE_SUBMENU, entries, nil)
+	return addCustomScrollableMenuEntry(text, callbackFunc, entryTypeConstants.LSM_ENTRY_TYPE_SUBMENU, entries, nil)
 end
 
 --Adds a divider line to the context menu entries

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.35
-## AddOnVersion: 020305
+## Version: 2.36
+## AddOnVersion: 020306
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101045 101046

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,9 +1,7 @@
 -v- ---------------LSM v2.36 - 2025-05-30--------------------------------------------------------------------------- -v-
-[WORKING ON]
--2025_34    Added .option "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
-
 [Added]
 -2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)
+-2025_34    Added .option "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
 
 [Changed]
 --2025_33	Changed params of API function AddCustomScrollableSubMenuEntry(text, entries, callbackFunc) -> Added callbackFunc. If provided the submenu opening entry will use this callback function once clicked

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,3 +1,8 @@
+-v- ---------------LSM v2.36 - 2025-05-08--------------------------------------------------------------------------- -v-
+[Added]
+-2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)
+
+
 -v- ---------------LSM v2.35 - 2025-04-06--------------------------------------------------------------------------- -v-
 [Fixed]
 -2025_6:	If multiSelection is enabled: LSM test Entry having a submenu AND a callback is selectable -> should not be the case
@@ -31,7 +36,6 @@
 
 [Changed]
 -2025_5:	Split up into several files
-
 
 -v- ---------------LSM v2.34 - 2025-02-07--------------------------------------------------------------------------- -v-
 -Added  option "maxDropdownWidth": Width of the dropdowns will be maximum this width (minimum width is 50, or 125 if the search editbox header is enabled. If the longest text of entries is < maxDropdownWidth then the dropdown's width will be the longest text entry width

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -2,6 +2,9 @@
 [Added]
 -2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)
 
+[Changed]
+--2025_33	Changed params of API function AddCustomScrollableSubMenuEntry(text, entries, callbackFunc) -> Added callbackFunc. If provided the submenu opening entry will use this callback function once clicked
+
 
 -v- ---------------LSM v2.35 - 2025-04-06--------------------------------------------------------------------------- -v-
 [Fixed]

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,4 +1,7 @@
--v- ---------------LSM v2.36 - 2025-05-08--------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.36 - 2025-05-30--------------------------------------------------------------------------- -v-
+[WORKING ON]
+-2025_34    Added .option "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
+
 [Added]
 -2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)
 

--- a/LibScrollableMenu/classes/comboBox_base.lua
+++ b/LibScrollableMenu/classes/comboBox_base.lua
@@ -1010,6 +1010,11 @@ function comboBox_base:GetMaxDropdownWidth()
 	return self.maxWidth --is set via options.maxDropdownWidth -> see table LSMOptionsToZO_ComboBoxOptionsCallbacks
 end
 
+function comboBox_base:GetMinDropdownWidth()
+	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 185, tos(self.minWidth)) end
+	return self.minWidth --is set via options.minDropdownWidth -> see table LSMOptionsToZO_ComboBoxOptionsCallbacks
+end
+
 function comboBox_base:GetDropdownObject(comboBoxContainer, depth)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 93, tos(getControlName(comboBoxContainer)), tos(depth)) end
 	self.m_nextFree = depth + 1
@@ -1565,7 +1570,12 @@ end
 function comboBox_base:UpdateWidth(control)
 	--d(debugPrefix .. "comboBox_base:UpdateWidth - control: " .. getControlName(control))
 	--Is the dropdown using a header control? then calculate it's size too
-	local minWidth = self:GetBaseWidth(control)
+	local baseWidth = self:GetBaseWidth(control)
+
+	--Get minWidth from settings
+	local minDropdownWidth = self:GetMinDropdownWidth() or baseWidth
+	local minWidth = (minDropdownWidth > baseWidth and minDropdownWidth) or baseWidth
+	if minWidth <= 0 then minWidth = baseWidth end
 
 	--Calculate the maximum width now: Maximum width explicitly set by options? Else use container's width (should be same as the dropdown opening ctrl).
 	-->Will be overwritten at Show function IF no maxWidth is set and any entry in the list is wider (text width) than the container width

--- a/LibScrollableMenu/classes/comboBox_class.lua
+++ b/LibScrollableMenu/classes/comboBox_class.lua
@@ -19,6 +19,8 @@ local dlog = libDebug.DebugLog
 --------------------------------------------------------------------
 --ZOs local speed-up/reference variables
 local tos = tostring
+local strlow = string.lower
+local stringType = "string"
 
 
 --------------------------------------------------------------------
@@ -172,7 +174,8 @@ function comboBoxClass:GetSubMenuOpeningSide() --#2025_34
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 186) end
 	local options = self:GetOptions()
 	local submenuOpenToSide = (options and getValueOrCallback(options.submenuOpenToSide, options)) or nil
-	return submenuOpenToSide
+d(debugPrefix .. "comboBoxClass:GetSubMenuOpeningSide - " ..tos(submenuOpenToSide))
+	return (type(submenuOpenToSide) == stringType and strlow(submenuOpenToSide)) or nil
 end
 
 function comboBoxClass:GetHiddenForReasons(button)

--- a/LibScrollableMenu/classes/comboBox_class.lua
+++ b/LibScrollableMenu/classes/comboBox_class.lua
@@ -174,7 +174,6 @@ function comboBoxClass:GetSubMenuOpeningSide() --#2025_34
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 186) end
 	local options = self:GetOptions()
 	local submenuOpenToSide = (options and getValueOrCallback(options.submenuOpenToSide, options)) or nil
-d(debugPrefix .. "comboBoxClass:GetSubMenuOpeningSide - " ..tos(submenuOpenToSide))
 	return (type(submenuOpenToSide) == stringType and strlow(submenuOpenToSide)) or nil
 end
 

--- a/LibScrollableMenu/classes/comboBox_class.lua
+++ b/LibScrollableMenu/classes/comboBox_class.lua
@@ -168,6 +168,13 @@ function comboBoxClass:GetMenuPrefix()
 	return 'Menu'
 end
 
+function comboBoxClass:GetSubMenuOpeningSide() --#2025_34
+	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 186) end
+	local options = self:GetOptions()
+	local submenuOpenToSide = (options and getValueOrCallback(options.submenuOpenToSide, options)) or nil
+	return submenuOpenToSide
+end
+
 function comboBoxClass:GetHiddenForReasons(button)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 130, tos(button)) end
 --d("111111111111111 comboBoxClass:GetHiddenForReasons - button: " ..tos(button))

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -1633,6 +1633,11 @@ function dropdownClass:Show(comboBox, itemTable, minWidth, maxWidth, maxHeight, 
 	-- prevent it from getting any skinnier than the container's initial width
 	local longestEntryTextWidth = largestEntryWidth + (ZO_COMBO_BOX_ENTRY_TEMPLATE_LABEL_PADDING * 2) + ZO_SCROLL_BAR_WIDTH
 
+	--Any options.minDropdownWidth "fixed width" chosen?
+	local minDropdownWidth = comboBoxObject:GetMinDropdownWidth()
+	if minDropdownWidth and minDropdownWidth > minWidth then
+		minWidth = minDropdownWidth
+	end
 	--Any options.maxDropdownWidth "fixed width" chosen?
 	local maxDropdownWidth = comboBoxObject:GetMaxDropdownWidth()
 	--If a maxWidth was set in the options then use that one, else use the auto-size of the longest entry. If the auto-size of the longest entry is smaller than the maxWidth, then use that instead!

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -328,8 +328,7 @@ local function setTimeout(callback)
 end
 
 local function checkWhereToShowSubmenu(selfVar) --#2025_34
-	--todo #2025_34 Implement submenuOpenToSide -> get it from the settings of the current dropdown object's LSMcomboBox
-	--todo or set self.submenuOpenToSide somewhere?
+--d(debugPrefix .. "dropdownClass:checkWhereToShowSubmenu - parentMenu: " ..tos(selfVar.m_parentMenu))
 	if not selfVar.m_parentMenu then return false, true end
 
 	local openSubmenuToSideForced = false
@@ -337,11 +336,12 @@ local function checkWhereToShowSubmenu(selfVar) --#2025_34
 
 	local submenuOpenToSide = selfVar:GetSubMenuOpeningSide()
 	if submenuOpenToSide ~= nil then
-		openToTheRight = ((submenuOpenToSide == "right" and true) or (submenuOpenToSide == "left" and false)) or nil
-		if openToTheRight ~= nil then
-			openSubmenuToSideForced  = true
-		else
+		if submenuOpenToSide == "right" then
 			openToTheRight = true
+			openSubmenuToSideForced  = true
+		elseif submenuOpenToSide == "left" then
+			openToTheRight = false
+			openSubmenuToSideForced  = true
 		end
 	end
 	return openSubmenuToSideForced, openToTheRight
@@ -1227,7 +1227,7 @@ function dropdownClass:AnchorToControl(parentControl)
 	local point, relativePoint = TOPLEFT, TOPRIGHT
 
 	--It's a submenu and got a parentMenu? Check if we should anchor to the right
-	if self.m_parentMenu then
+	if self.m_parentMenu ~= nil then
 		openSubmenuToSideForced, right = checkWhereToShowSubmenu(self) --#2025_34
 
 		local parentDropdownObject = self.m_parentMenu.m_dropdownObject
@@ -1263,20 +1263,20 @@ end
 function dropdownClass:AnchorToMouse()
 	local menuToAnchor = self.control
 
-	local x, y = GetUIMousePosition()
-	local width, height = GuiRoot:GetDimensions()
+	local x, y                        = GetUIMousePosition()
+	local GUIRootWidth, GUIRootHeight = GuiRoot:GetDimensions()
 
 	menuToAnchor:ClearAnchors()
 
 	local openSubmenuToSideForced, right = checkWhereToShowSubmenu(self) --#2025_34
 	if not openSubmenuToSideForced then
-		if x + menuToAnchor:GetWidth() > width then
+		if (x + menuToAnchor:GetWidth()) > GUIRootWidth then
 			right = false
 		end
 	end
 
 	local bottom = true
-	if y + menuToAnchor:GetHeight() > height then
+	if (y + menuToAnchor:GetHeight()) > GUIRootHeight then
 		bottom = false
 	end
 

--- a/LibScrollableMenu/classes/subMenu_class.lua
+++ b/LibScrollableMenu/classes/subMenu_class.lua
@@ -48,7 +48,7 @@ local getValueOrCallback = libUtil.getValueOrCallback
 local SubOrContextMenu_highlightControl = libUtil.SubOrContextMenu_highlightControl
 local checkIfHiddenForReasons = libUtil.checkIfHiddenForReasons
 local getContextMenuReference = libUtil.getContextMenuReference
-local libUtil_BelongsToContextMenuCheck = libUtil.belongsToContextMenuCheck
+--local libUtil_BelongsToContextMenuCheck = libUtil.belongsToContextMenuCheck
 
 local g_contextMenu
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -274,9 +274,9 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.35 - Updated 2025-04-06
+	CHANGELOG Current version: 2.36 - Updated 2025-05-08
 ---------------------------------------------------------------
-Max error #: 2025_31
+Max error #: 2025_32
 
 [KNOWN PROBLEMS]
 
@@ -284,37 +284,11 @@ Max error #: 2025_31
 [WORKING ON]
 
 [Fixed]
--2025_6:	If multiSelection is enabled: LSM test Entry having a submenu AND a callback is selectable -> should not be the case
--2025_7:	If multiselection is enabled: LSM test Maximum number of selectable entries (maxNumSelections) is not working (maybe after submenus were opened)
--2025_8:	Removed globally leaking variables
--2025_9:	If multiSelection is disabled: Entries opening a submenu, having a callback, do not select the submenu entry anymore
--2025_12:   multiselection options added will properly pass in the whole options table as param to the callback function now
--2025_13:	ContextMenu: Clicked outside will close the contextmenu now first and leave the other LSM menus opened
--2025_14:   For multiselect: Replace PlaySound with LSM sound handler for selected entry
--2025_16:   ContextMenu: Clicking a checkbox in a context menu's submenu will close the contextmenu. LSM test, entry "Submenu entry 6" -> nested submenus -> Checkbox
--2025_15:   ContextMenu: If one opens a nested submenu of a nested submenu, the total context menu closes all of sudden? LSM test, entry "Submenu entry 6" -> nested submenus -> OnMouseEnter of the 2nd depth submenu closes all
--2025_17:   Clicking a button still plays the click sound even if options.selectedSoundDisabled was set to true
--2025_18:   ContextMenu: Clicking any non-contextmenu submenu entry below the context menu, will select the submenu entry and close the submenu (but it should only close the contextmenu)
--2025_19:   ContextMenu: Clicking a context menu entry where multiselection is enabled, but the clicked entry of the context menu is not above the LSM (in background) anymore, the context menu closes even though an entry was clicked
--2025_20:   ContextMenu: Clicking a context menu's submenu entry where multiselection is enabled, but the clicked entry of the context menu is not above the LSM (in background) anymore, the context menu closes even though an entry was clicked
--2025_21:   ContextMenu: If multiSelection is disabled in a contextmenu by default the list of the menu was always empty
--2025_22:   ContextMenu: Trying to show a context menu on another context menu will just clear and hide the contextmenu now
--2025_23:   ContextMenu: Clicking the reset button closes the contextmenu
--2025_24:   ContextMenu: If one opens a nested submenu of a nested submenu, and then onMouseEnter another context menu entry, the submenu stays opened
--2025_25:   If multiselection is enabled: Selecting a ZO_Menu context menu entry at the filter header context menu sets cntxTxtSearchEntryClicked = true, and if you directly click outside the combobox/dropdown, or at the dropdown's open/close main control afterwards, the dropdown does not close anymore
--2025_26:   Filter header: If the filter header filtered all items and we left click the "No search results" entry it will call the callback of another LSM control (looks like the last entry of m_sortedItems of that combobox) all of sudden?
--2025_27: 	ContextMenu: Opening an LSM contextMenu, after another was used before, does use some options of the before opened LSM contextMenu then (e.g. the filter header) -> Reset of all options on each contextMenu open
--2025_28: 	ContextMenu: API function RunCustomScrollableMenuItemsCallback is not respecting the parameter fromParentMenu
--2025_29	ContextMenu: Opening a contextmenu on another control, while another LSM was opened, cleared the contextMenu entries
--2025_30:   ContextMenu: Opening a contextmenu sometimes does not change the maximum width of the entries properly
-
 
 [Added]
--2025_10:	If multiselection is enabled: Submenus with a selection can show the submenu arrow colored differently. option.multiSelectSubmenuSelectedArrowColor defines the color to use (default is white)
--2025_11:	If multiselection is not enabled: Submenus can show the submenu arrow colored differently. option.submenuArrowColor defines the color to use (default is white)
+-2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)
 
 [Changed]
--2025_5:	Split up into several files
 
 [Removed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -274,14 +274,15 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.36 - Updated 2025-05-08
+	CHANGELOG Current version: 2.36 - Updated 2025-05-30
 ---------------------------------------------------------------
-Max error #: 2025_32
+Max error #: 2025_34
 
 [KNOWN PROBLEMS]
 
 
 [WORKING ON]
+-2025_34    Added .ption "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
 
 [Fixed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -289,6 +289,7 @@ Max error #: 2025_32
 -2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)
 
 [Changed]
+--2025_33	Changed params of API function AddCustomScrollableSubMenuEntry(text, entries, callbackFunc) -> Added callbackFunc. If provided the submenu opening entry will use this callback function once clicked
 
 [Removed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -282,7 +282,7 @@ Max error #: 2025_34
 
 
 [WORKING ON]
--2025_34    Added .ption "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
+-2025_34    Added .option "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
 
 [Fixed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -282,12 +282,11 @@ Max error #: 2025_34
 
 
 [WORKING ON]
--2025_34    Added .option "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
-
 [Fixed]
 
 [Added]
 -2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)
+-2025_34    Added .option "submenuOpenToSide": Open the submenu forced to a specified side, e.g. "left" or "right". If this option is not specified the submenu autmatically chooses where to open to based on the available space left until the menu's width touches the screen's edge.
 
 [Changed]
 --2025_33	Changed params of API function AddCustomScrollableSubMenuEntry(text, entries, callbackFunc) -> Added callbackFunc. If provided the submenu opening entry will use this callback function once clicked

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -534,6 +534,7 @@ local LSMOptionsKeyToZO_ComboBoxOptionsKey = {
 	["sortType"] = 				"m_sortType",
 	["spacing"] = 				"m_spacing",
 	["submenuArrowColor"] =		"submenuArrowColor",
+	["submenuOpenToSide"] =		"submenuOpenToSide",
 	["multiSelectSubmenuSelectedArrowColor"] = "multiSelectSubmenuSelectedArrowColor",
 	["visibleRowsDropdown"] =	"visibleRows",
 }
@@ -735,6 +736,7 @@ local submenuClass_exposedVariables = {
 	["m_highlightTemplate"] = true,
 	["narrateData"] = true,
 	["submenuArrowColor"] =	 true,
+	["submenuOpenToSide"] = true,
 	["multiSelectSubmenuSelectedArrowColor"] = true,
 	["useDefaultHighlightForSubmenuWithCallback"] = true,
 	["visibleRowsSubmenu"] = true, --we only need this "visibleRowsSubmenu" for the submenus, mainMenu uses visibleRowsDropdown

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -6,7 +6,7 @@ if LibScrollableMenu ~= nil then return end -- the same or newer version of this
 local lib = ZO_CallbackObject:New()
 lib.name = "LibScrollableMenu"
 lib.author = "Baertram, IsJustaGhost, tomstock, Kyoma"
-lib.version = "2.35"
+lib.version = "2.36"
 if not lib then return end
 --------------------------------------------------------------------
 
@@ -527,6 +527,7 @@ local LSMOptionsKeyToZO_ComboBoxOptionsKey = {
 	["font"] = 					"m_font",
 	["maxDropdownHeight"] =		"maxHeight",
 	["maxDropdownWidth"] =		"maxWidth",
+	["minDropdownWidth"] =		"minWidth",
 	["preshowDropdownFn"] = 	"m_preshowDropdownFn",
 	["sortEntries"] = 			"m_sortsItems",
 	["sortOrder"] = 			"m_sortOrder",
@@ -619,6 +620,10 @@ local LSMOptionsToZO_ComboBoxOptionsCallbacks = {
 	end,
 	["maxDropdownWidth"] = function(comboBoxObject, maxDropdownWidth)
 		comboBoxObject.maxWidth = maxDropdownWidth
+		comboBoxObject:UpdateWidth(comboBoxObject.m_dropdown)
+	end,
+	["minDropdownWidth"] = function(comboBoxObject, minDropdownWidth)
+		comboBoxObject.minWidth = minDropdownWidth
 		comboBoxObject:UpdateWidth(comboBoxObject.m_dropdown)
 	end,
 	["maxNumSelections"] = function(comboBoxObject, maxNumSelections)
@@ -726,6 +731,7 @@ local submenuClass_exposedVariables = {
 	["options"] = true,
 	["maxDropdownHeight"] = true,
 	["maxDropdownWidth"] = true,
+	["minDropdownWidth"] = true,
 	["m_highlightTemplate"] = true,
 	["narrateData"] = true,
 	["submenuArrowColor"] =	 true,
@@ -841,5 +847,3 @@ constants.sounds.entryTypeToOriginalSelectedSound = entryTypeToOriginalSelectedS
 -- Global library reference
 ------------------------------------------------------------------------------------------------------------------------
 LibScrollableMenu = lib
-
-

--- a/LibScrollableMenu/debug/LSM_debug.lua
+++ b/LibScrollableMenu/debug/LSM_debug.lua
@@ -225,6 +225,7 @@ local debugLogMessagePatterns = {
 	[182] = "doSubmenuOnMouseEnterNestedSubmenuChecks",
 	[183] = "checkSubmenuOnMouseEnterTasks",
 	[184] = "updateSubmenuIsAnyEntrySelectedStatus",
+	[185] = "comboBox_base:GetMinDropdownWidth - minDropdownWidth: %s",
 }
 
 

--- a/LibScrollableMenu/debug/LSM_debug.lua
+++ b/LibScrollableMenu/debug/LSM_debug.lua
@@ -226,6 +226,7 @@ local debugLogMessagePatterns = {
 	[183] = "checkSubmenuOnMouseEnterTasks",
 	[184] = "updateSubmenuIsAnyEntrySelectedStatus",
 	[185] = "comboBox_base:GetMinDropdownWidth - minDropdownWidth: %s",
+	[186] = "comboBoxClass:GetSubMenuOpeningSide"
 }
 
 


### PR DESCRIPTION
-v- ---------------LSM v2.36 - 2025-05-08--------------------------------------------------------------------------- -v-
[Added]
-2025_32    Added  option "minDropdownWidth": Width of the dropdowns will be minimum this width (minimum width is 50, or 125 if the search editbox header is enabled. Attention: If the minDropdownWidth is > than the max it will overwrite the maximum dropdown width that way!)

[Changed]
--2025_33	Changed params of API function AddCustomScrollableSubMenuEntry(text, entries, callbackFunc) -> Added callbackFunc. If provided the submenu opening entry will use this callback function once clicked

