### PR TITLE
Version 2 3 8

### DIFF
--- a/ESOUI_description.txt
+++ b/ESOUI_description.txt
@@ -174,7 +174,7 @@ LSM_ENTRY_TYPE_SLIDER
 --A new context menu should be using ClearCustomScrollableMenu() before it adds the first entries (to hide other contextmenus and clear the new one).
 --After that use either AddCustomScrollableMenuEntry to add single entries, AddCustomScrollableMenuEntries to add a whole entries table/function
 --returning a table, or even directly use AddCustomScrollableMenu and pass in the entrie/function to get entries.
---And after adding all entries, call ShowCustomScrollableMenu(parentControl) to show the menu at the parentControl. If no control is provided
+--And after adding all entries, call ShowCustomScrollableMenu(controlToAnchorTo, options, specialCallbackData) to show the menu at the parentControl. If no control is provided
 --moc() (control below mouse cursor) will be used
 -->Attention: ClearCustomScrollableMenu() will clear and hide ALL LSM contextmenus at any time! So we cannot have an LSM context menu to show at another
 --LSM context menu entry (similar to ZO_Menu).
@@ -232,6 +232,7 @@ LSM_ENTRY_TYPE_SLIDER
 --		--[[ Attention: additionalData keys which are maintained in table LSMOptionsKeyToZO_ComboBoxOptionsKey will be mapped to ZO_ComboBox's key and taken over into the entry.data[ZO_ComboBox's key]. All other "custom keys" will stay in entry.data.additionalData[key]! ]]
 --)
 ---> returns nilable:number indexOfNewAddedEntry, nilable:table newEntryData
+function AddCustomScrollableMenuEntry(text, callback, entryType, entries, additionalData)
 
 
 --Adds an entry having a submenu (or maybe nested submenues) in the entries table/entries function whch returns a table
@@ -297,12 +298,36 @@ function SetCustomScrollableMenuOptions(options, comboBoxContainer)
 
 --Show the custom scrollable context menu now at the control controlToAnchorTo, using optional options.
 --If controlToAnchorTo is nil it will be anchored to the current control's position below the mouse, like ZO_Menu does
+--Optional table specialCallbackData can be used to register an onShowCallback or onHideCallback function for your unqiue addon name,
+--so you can react on an "Show" and/or "Hide" of this particular context menu. Registered callback functions will be executed in order of register!
+--You can pass in any other variable with the same table. The whole table will passed to the callback function's signature, and to the uniqueAddonName generating function.
+-- The signature of the table must follow this example:
+--  { addonName = string or function returning a string "UniqueString", onShowCallback = function(comboBox, openingControl, specialData) end, onHideCallback = function(comboBox, openingControl, specialData) end, anyOtherVariableToPassInToTheCallback=anyValue, ... }
 --Existing context menu entries will be kept (until ClearCustomScrollableMenu will be called)
-function ShowCustomScrollableMenu(controlToAnchorTo, options)
+function ShowCustomScrollableMenu(controlToAnchorTo, options, specialCallbackData)
 
 
 --Hide the custom scrollable context menu and clear it's entries, clear internal variables, mouse clicks etc.
 function ClearCustomScrollableMenu()
+
+
+--API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)
+-->Parameter updateMode can be left empty, then the system will automatically determine if a submenu exists and the item belongs to that, and refresh that,
+--or it will update the mainmenu if it exists.
+--Or you specify one of the following updateModes:
+--->LSM_UPDATE_MODE_MAINMENU	Only update the mainmenu visually
+--->LSM_UPDATE_MODE_SUBMENU		Only update the submenu visually
+--->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
+---Parameter comboBox is optional
+function RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
+
+
+--Returns boolean true/false if any LSM context menu is currently showing it's dropdown
+IsCustomScrollableContextMenuShown()
+
+
+--Returns boolean true/false if any LSM menu is currently showing it's dropdown
+IsCustomScrollableMenuShown()
 
 
 --Can be used within a callback function of any entry:
@@ -345,7 +370,18 @@ function GetCustomScrollableMenuRowData(rowControl)
 -- API to set all buttons in a group based on Select all, Unselect All, Invert all.
 -->Used in "checkbox" buttonGroup to show the default context menu (if no custom contextmenu was provided!) at a control which provides the
 -->"Select all", "Deselect all" and "Invert selection" entries
-function LibScrollableMenu.SetButtonGroupState
+function LibScrollableMenu.ButtonGroupDefaultContextMenu
+
+
+Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Manual call via API function UpdateCustomScrollableMenuEntryIconPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
+UpdateCustomScrollableMenuEntryIconPath(comboBox, control, data)
+
+Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
+--> checkFunc(comboBox, control, data)
+--Manual call via API function UpdateCustomScrollableMenuEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
+UpdateCustomScrollableMenuEntryPath(comboBox, control, data, checkFunc, checkFuncParam1, checkFuncParam2, ...)
 [/code]
 
 

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -700,6 +700,7 @@ end
 --->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
 ---Parameter comboBox is optional
 local function LSM_RefreshLibScrollableMenu(mocCtrl, updateMode, comboBox)
+--d("[RefreshCustomScrollableMenu] - moc: " .. getControlName(mocCtrl) .. "; updateMode: " ..tos(updateMode) .. "; comboBox: " .. tos(comboBox))
     --Update the visible LSM dropdown's submenu now so the disabled state and checkbox values commit again
 	if mocCtrl ~= nil then
 		if comboBox == nil then
@@ -709,22 +710,34 @@ local function LSM_RefreshLibScrollableMenu(mocCtrl, updateMode, comboBox)
 
 		--Main Menu
 		if updateMode == LSM_UPDATE_MODE_BOTH or updateMode == LSM_UPDATE_MODE_MAINMENU then
-			local owningWindow = mocCtrl.GetOwningWindow ~= nil and mocCtrl:GetOwningWindow() or nil
-			local mainMenuDropdown = (owningWindow and owningWindow.m_dropdownObject) or nil
+			--local owningWindow = mocCtrl.GetOwningWindow ~= nil and mocCtrl:GetOwningWindow() or nil
+			--local mainMenuDropdown = (owningWindow and owningWindow.m_dropdownObject) or nil
+			local mainMenuComboBox = (mocCtrl.m_owner ~= nil and mocCtrl.m_owner.m_comboBox) or nil
+			local mainMenuDropdown = (mainMenuComboBox ~= nil and mainMenuComboBox.m_dropdownObject) or nil
 			if mainMenuDropdown ~= nil then
-				mainMenuDropdown:SubmenuOrCurrentListRefresh(mocCtrl, true, true)
+				if mainMenuComboBox:IsDropdownVisible() == true then
+					mainMenuDropdown:SubmenuOrCurrentListRefresh(mocCtrl, true, true)
+				end
 			end
 		end
 
 		--Submenu
 		if updateMode == LSM_UPDATE_MODE_BOTH or updateMode == LSM_UPDATE_MODE_SUBMENU then
-			if comboBox and comboBox:IsDropdownVisible() == true and mocCtrl.m_dropdownObject then
+			if mocCtrl.m_dropdownObject and comboBox and comboBox:IsDropdownVisible() == true then
 				mocCtrl.m_dropdownObject:SubmenuOrCurrentListRefresh(mocCtrl, true, false)
 			end
 		end
 	end
 end
 RefreshCustomScrollableMenu = LSM_RefreshLibScrollableMenu
+
+--Returns boolean true/false if any LSM context menu is currently showing it's dropdown
+local function LSM_IsContextMenuShown()
+	g_contextMenu = updateContextMenuRef()
+	if g_contextMenu == nil then return false end
+	return g_contextMenu:IsDropdownVisible()
+end
+IsCustomScrollableContextMenuShown = LSM_IsContextMenuShown
 
 
 -- API to show a context menu at a buttonGroup where you can (un)check/invert all buttons in a group:

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -196,7 +196,7 @@ function AddCustomScrollableComboBoxDropdownMenu(parent, comboBoxContainer, opti
 	assert(comboBox and comboBox.IsInstanceOf and comboBox:IsInstanceOf(ZO_ComboBox), MAJOR .. ' | The comboBoxContainer you supplied must be a valid ZO_ComboBox container. "comboBoxContainer.m_comboBox:IsInstanceOf(ZO_ComboBox)"')
 
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 161, tos(getControlName(parent)), tos(getControlName(comboBoxContainer)), tos(options)) end
-	comboBoxClass.UpdateMetatable(comboBox, parent, comboBoxContainer, options) --Calls comboboxCLass:Initialize
+	comboBoxClass.UpdateMetatable(comboBox, parent, comboBoxContainer, options) --Calls comboboxClass:Initialize
 
 	return comboBox.m_dropdownObject
 end
@@ -699,7 +699,7 @@ end
 --->LSM_UPDATE_MODE_SUBMENU		Only update the submenu visually
 --->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
 ---Parameter comboBox is optional
-local function LSM_RefreshLibScrollableMenu(mocCtrl, updateMode, comboBox)
+local function LSM_RefreshLibScrollableMenu(mocCtrl, updateMode, comboBox) -- #2025_58
 --d("[RefreshCustomScrollableMenu] - moc: " .. getControlName(mocCtrl) .. "; updateMode: " ..tos(updateMode) .. "; comboBox: " .. tos(comboBox))
     --Update the visible LSM dropdown's submenu now so the disabled state and checkbox values commit again
 	if mocCtrl ~= nil then
@@ -732,13 +732,24 @@ end
 RefreshCustomScrollableMenu = LSM_RefreshLibScrollableMenu
 
 --Returns boolean true/false if any LSM context menu is currently showing it's dropdown
-local function LSM_IsContextMenuShown()
+local function LSM_IsContextMenuCurrentlyShown()
 	g_contextMenu = updateContextMenuRef()
 	if g_contextMenu == nil then return false end
 	return g_contextMenu:IsDropdownVisible()
 end
-IsCustomScrollableContextMenuShown = LSM_IsContextMenuShown
+IsCustomScrollableContextMenuShown = LSM_IsContextMenuCurrentlyShown --#2025_59
 
+local function LSM_IsLSMCurrentlyShown()
+	local LSM_menus = lib._objects
+	if ZO_IsTableEmpty(LSM_menus) then return false end
+	for _, LSM_menu in ipairs(LSM_menus) do
+		if LSM_menu ~= nil and LSM_menu.IsDropdownVisible then
+			if LSM_menu:IsDropdownVisible() then return true end
+		end
+	end
+	return LSM_IsContextMenuCurrentlyShown()
+end
+IsCustomScrollableMenuShown = LSM_IsLSMCurrentlyShown --#2025_60
 
 -- API to show a context menu at a buttonGroup where you can (un)check/invert all buttons in a group:
 -- Select all, Unselect All, Invert all.
@@ -807,12 +818,12 @@ lib.ButtonGroupDefaultContextMenu = buttonGroupDefaultContextMenu
 --]Defined in dropdown_class.lua[--
 
 --#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
---Manual call via API function lib.UpdateIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
---lib.UpdateIconsPath(comboBox, control, data)
+--Manual call via API function UpdateCustomScrollableMenuEntryIconPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
+--UpdateCustomScrollableMenuEntryIconPath(comboBox, control, data)
 
 --#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
 --Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
 --> checkFunc(comboBox, control, data)
---Manual call via API function lib.UpdateEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
---lib.UpdateEntryPath(comboBox, control, data, checkFunc)
+--Manual call via API function UpdateCustomScrollableMenuEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
+--UpdateCustomScrollableMenuEntryPath(comboBox, control, data, checkFunc, checkFuncParam1, checkFuncParam2, ...)
 ]]

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -135,6 +135,9 @@ end
 --		function customFilterFunc				A function returning a boolean true: show item / false: hide item. Signature of function: customFilterFunc(item, filterString)
 --->  === Dropdown callback functions
 -- 		function preshowDropdownFn:optional 	function function(ctrl) codeHere end: to run before the dropdown shows
+--->  === Dropdown Refresh functions
+--		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the scrolllist should happen, if you click/change any entry's value. This would be needed
+--												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 --->  === Dropdown's Custom XML virtual row/entry templates ============================================================
 --		boolean useDefaultHighlightForSubmenuWithCallback	Boolean or function returning a boolean if always the default ZO_ComboBox highlight XML template should be used for an entry having a submenu AND a callback function. If false the highlight 'LibScrollableMenu_Highlight_Green' will be used
 --		table XMLRowTemplates:optional			Table or function returning a table with key = row type of lib.scrollListRowTypes and the value = subtable having

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -692,7 +692,8 @@ function RunCustomScrollableMenuItemsCallback(comboBox, item, myAddonCallbackFun
 end
 
 
--- API to show a context menu at a buttonGrouop where you can set all buttons in a group based on Select all, Unselect All, Invert all.
+-- API to show a context menu at a buttonGroup where you can (un)check/invert all buttons in a group:
+-- Select all, Unselect All, Invert all.
 function buttonGroupDefaultContextMenu(comboBox, control, data)
 	local buttonGroup = comboBox.m_buttonGroup
 	if buttonGroup == nil then return end
@@ -750,3 +751,20 @@ function buttonGroupDefaultContextMenu(comboBox, control, data)
 end
 lib.SetButtonGroupState = buttonGroupDefaultContextMenu --Only for compatibilitxy (if any other addon was using 'SetButtonGroupState' already)
 lib.ButtonGroupDefaultContextMenu = buttonGroupDefaultContextMenu
+
+
+--======================================================================================================================
+--[[ Other API functions available:
+
+--]Defined in dropdown_class.lua[--
+
+--#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Manual call via API function lib.UpdateIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
+--lib.UpdateIconsPath(comboBox, control, data)
+
+--#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
+--> checkFunc(comboBox, control, data)
+--Manual call via API function lib.UpdateEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
+--lib.UpdateEntryPath(comboBox, control, data, checkFunc)
+]]

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -691,6 +691,41 @@ function RunCustomScrollableMenuItemsCallback(comboBox, item, myAddonCallbackFun
 	return true, myAddonCallbackFunc(comboBox, item, itemsForCallbackFunc, ...)
 end
 
+--API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)
+-->Parameter updateMode can be left empty, then the system will automatically determine if a submenu exists and the item belongs to that, and refresh that,
+--or it will update the mainmenu if it exists.
+--Or you specify one of the following updateModes:
+--->LSM_UPDATE_MODE_MAINMENU	Only update the mainmenu visually
+--->LSM_UPDATE_MODE_SUBMENU		Only update the submenu visually
+--->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
+---Parameter comboBox is optional
+local function LSM_RefreshLibScrollableMenu(mocCtrl, updateMode, comboBox)
+    --Update the visible LSM dropdown's submenu now so the disabled state and checkbox values commit again
+	if mocCtrl ~= nil then
+		if comboBox == nil then
+			comboBox = (mocCtrl.m_comboBox or (mocCtrl.m_owner and mocCtrl.m_owner.m_comboBox)) or nil
+		end
+		if comboBox == nil then return end
+
+		--Main Menu
+		if updateMode == LSM_UPDATE_MODE_BOTH or updateMode == LSM_UPDATE_MODE_MAINMENU then
+			local owningWindow = mocCtrl.GetOwningWindow ~= nil and mocCtrl:GetOwningWindow() or nil
+			local mainMenuDropdown = (owningWindow and owningWindow.m_dropdownObject) or nil
+			if mainMenuDropdown ~= nil then
+				mainMenuDropdown:SubmenuOrCurrentListRefresh(mocCtrl, true, true)
+			end
+		end
+
+		--Submenu
+		if updateMode == LSM_UPDATE_MODE_BOTH or updateMode == LSM_UPDATE_MODE_SUBMENU then
+			if comboBox and comboBox:IsDropdownVisible() == true and mocCtrl.m_dropdownObject then
+				mocCtrl.m_dropdownObject:SubmenuOrCurrentListRefresh(mocCtrl, true, false)
+			end
+		end
+	end
+end
+RefreshCustomScrollableMenu = LSM_RefreshLibScrollableMenu
+
 
 -- API to show a context menu at a buttonGroup where you can (un)check/invert all buttons in a group:
 -- Select all, Unselect All, Invert all.

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -135,8 +135,9 @@ end
 --		function customFilterFunc				A function returning a boolean true: show item / false: hide item. Signature of function: customFilterFunc(item, filterString)
 --->  === Dropdown callback functions
 -- 		function preshowDropdownFn:optional 	function function(ctrl) codeHere end: to run before the dropdown shows
---->  === Dropdown Refresh functions
---		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the scrolllist should happen, if you click/change any entry's value. This would be needed
+--		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the normal scrolllist should happen, if you click/change any entry's value. This would be needed
+--												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
+--		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrolllist should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 --->  === Dropdown's Custom XML virtual row/entry templates ============================================================
 --		boolean useDefaultHighlightForSubmenuWithCallback	Boolean or function returning a boolean if always the default ZO_ComboBox highlight XML template should be used for an entry having a submenu AND a callback function. If false the highlight 'LibScrollableMenu_Highlight_Green' will be used

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -700,14 +700,15 @@ end
 --->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
 ---Parameter comboBox is optional
 local function LSM_RefreshLibScrollableMenu(mocCtrl, updateMode, comboBox) -- #2025_58
+	--Update the visible LSM dropdown's submenu now so the disabled state and checkbox values commit again
+	if mocCtrl == nil then mocCtrl = moc() end
 --d("[RefreshCustomScrollableMenu] - moc: " .. getControlName(mocCtrl) .. "; updateMode: " ..tos(updateMode) .. "; comboBox: " .. tos(comboBox))
-    --Update the visible LSM dropdown's submenu now so the disabled state and checkbox values commit again
 	if mocCtrl ~= nil then
 		if comboBox == nil then
 			comboBox = (mocCtrl.m_comboBox or (mocCtrl.m_owner and mocCtrl.m_owner.m_comboBox)) or nil
 		end
 		if comboBox == nil then return end
-
+--d(">[LSM]found combobox")
 		--Main Menu
 		if updateMode == LSM_UPDATE_MODE_BOTH or updateMode == LSM_UPDATE_MODE_MAINMENU then
 			--local owningWindow = mocCtrl.GetOwningWindow ~= nil and mocCtrl:GetOwningWindow() or nil
@@ -724,6 +725,7 @@ local function LSM_RefreshLibScrollableMenu(mocCtrl, updateMode, comboBox) -- #2
 		--Submenu
 		if updateMode == LSM_UPDATE_MODE_BOTH or updateMode == LSM_UPDATE_MODE_SUBMENU then
 			if mocCtrl.m_dropdownObject and comboBox and comboBox:IsDropdownVisible() == true then
+--d(">[LSM[refresh submenu - TRY")
 				mocCtrl.m_dropdownObject:SubmenuOrCurrentListRefresh(mocCtrl, true, false)
 			end
 		end

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -600,7 +600,7 @@ LSM_Debug.cntxtMenuControlToAnchorTo = controlToAnchorTo
 end
 local showCustomScrollableMenu = ShowCustomScrollableMenu
 
---Run a callback function myAddonCallbackFunc passing in the entries of the opening menu/submneu of a clicked LSM context menu item
+--Run a callback function myAddonCallbackFunc passing in the entries of the opening menu/submenu of a clicked LSM context menu item
 -->Parameters of your function myAddonCallbackFunc must be:
 -->function myAddonCallbackFunc(userdata LSM_comboBox, userdata selectedContextMenuItem, table openingMenusEntries, ...)
 -->... can be any additional params that your function needs, and must be passed in to the ... of calling API function RunCustomScrollableMenuItemsCallback too!
@@ -658,7 +658,7 @@ function RunCustomScrollableMenuItemsCallback(comboBox, item, myAddonCallbackFun
 	local sortedItems = getComboBoxsSortedItems(comboBox, fromParentMenuValue, false)
 	if ZO_IsTableEmpty(sortedItems) then
 --d("<sortedItems are empty!")
-		return false
+		return false, nil
 	end
 
 	local itemsForCallbackFunc = sortedItems

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.37
-## AddOnVersion: 020307
+## Version: 2.38
+## AddOnVersion: 020308
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101047 101048

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -9,7 +9,7 @@
 ## AddOnVersion: 020308
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
-## APIVersion: 101047 101048
+## APIVersion: 101048 101049
 ## OptionalDependsOn: LibDebugLogger>=263
 ## SavedVariables: LibScrollableMenu_SavedVars
 

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -46,4 +46,4 @@ LSM_API.lua
 ## Uncomment test/LSM_test.lua to test the combobox with different menu entryTypes and submenus
 ## Use slash command /lsmtest to show the test UI
 ## Inspect the code in LSM_test.lua file to see how the API functions, data tables, handlers, callbacks etc. work
-test/LSM_test.lua
+## test/LSM_test.lua

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,6 +1,10 @@
 -v- ---------------LSM v2.38 - 2025-10-21--------------------------------------------------------------------------- -v-
 [WORKING ON]
-#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+-#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+-Added options.automaticRefresh
+--->  === Dropdown Refresh functions
+--		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the scrolllist should happen, if you click/change any entry's value. This would be needed
+--												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 
 
 -v- ---------------LSM v2.37 - 2025-09-21--------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -3,8 +3,16 @@
 #2025_48 Search header is not searching an editBox's text or a slider's balue (only the label's text in front)
 
 [WORKING ON]
-#2025_44 New API function lib.OnEntryCallbackUpdateIcons to check from submenu up to main menu if any icon needs an update at the current path.
---> todo: Automatically called if an entry's data contains data.recursiveIconUpdate = true
+--#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Manual call via API function lib.UpdateIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
+--lib.UpdateIconsPath(comboBox, control, data)
+
+--#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
+--> checkFunc(comboBox, control, data)
+--Manual call via API function lib.UpdateEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
+--lib.UpdateEntryPath(comboBox, control, data, checkFunc)
+
 
 [Fixed]
 #2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner == LSM menu should take place then to suppress the close of the menu?
@@ -23,12 +31,10 @@
 -Added options.automaticRefresh
 -Added options.automaticSubmenuRefresh
 --->  === Dropdown Refresh functions
---		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the normal scrolllist should happen, if you click/change any entry's value. This would be needed
+--		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the normal scrollList should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
---		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrolllist should happen, if you click/change any entry's value. This would be needed
+--		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrollList should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
-#2025_44 Added API function lib.UpdateIconsRecursively(comboBox, rowControl, optional: data) Update the path upwards from submenu's rowControl to the parent menus and refresh the icons at the entries. Can be called manually from a callback of any submenu entry e.g. or will be automatically called if the submenu's entry data.recursiveIconUpdate == true
--->2nd part entry data.recursiveIconUpdate == true is still open -> 20251023
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
 
 

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -36,7 +36,17 @@
 --		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrollList should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
-
+#2025_58 API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)
+-->Parameter updateMode can be left empty, then the system will automatically determine if a submenu exists and the item belongs to that, and refresh that,
+--or it will update the mainmenu if it exists.
+--Or you specify one of the following updateModes:
+--->LSM_UPDATE_MODE_MAINMENU	Only update the mainmenu visually
+--->LSM_UPDATE_MODE_SUBMENU		Only update the submenu visually
+--->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
+---Parameter comboBox is optional
+RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
+#2025_59 Added API function IsCustomScrollableContextMenuShown
+--Returns boolean true/false if any LSM context menu is currently showing it's dropdown
 
 
 -v- ---------------LSM v2.37 - 2025-09-21--------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -9,7 +9,7 @@
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 --		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrolllist should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
-
+#2025_44 Added API function lib.UpdateIconsRecursively(comboBox, rowControl, optional: data) Update the path upwards from submenu's rowControl to the parent menus and refresh the icons at the entries. Can be called manually from a callback of any submenu entry e.g. or will be automatically called if the submenu's entry data.recursiveIconUpdate == true
 
 -v- ---------------LSM v2.37 - 2025-09-21--------------------------------------------------------------------------- -v-
 [Added]

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,9 +1,13 @@
 -v- ---------------LSM v2.38 - 2025-10-21--------------------------------------------------------------------------- -v-
-[WORKING ON]
--#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+[Added]
+#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+#2025_43 Automatically fix wrong formated .icon table format
 -Added options.automaticRefresh
+-Added options.automaticSubmenuRefresh
 --->  === Dropdown Refresh functions
---		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the scrolllist should happen, if you click/change any entry's value. This would be needed
+--		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the normal scrolllist should happen, if you click/change any entry's value. This would be needed
+--												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
+--		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrolllist should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 
 

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,3 +1,8 @@
+-v- ---------------LSM v2.38 - 2025-10-21--------------------------------------------------------------------------- -v-
+[WORKING ON]
+#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+
+
 -v- ---------------LSM v2.37 - 2025-09-21--------------------------------------------------------------------------- -v-
 [Added]
 -2025_37    Added API function AddCustomScrollableMenuRadioButton(text, callback, checked, buttonGroup, additionalData)

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -10,6 +10,8 @@
 --		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrolllist should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 #2025_44 Added API function lib.UpdateIconsRecursively(comboBox, rowControl, optional: data) Update the path upwards from submenu's rowControl to the parent menus and refresh the icons at the entries. Can be called manually from a callback of any submenu entry e.g. or will be automatically called if the submenu's entry data.recursiveIconUpdate == true
+#2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
+
 
 -v- ---------------LSM v2.37 - 2025-09-21--------------------------------------------------------------------------- -v-
 [Added]

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,17 +1,6 @@
--v- ---------------LSM v2.38 - 2025-10-23--------------------------------------------------------------------------- -v-
-[KNOWN PROBLEMS]
-#2025_48 Search header is not searching an editBox's text or a slider's balue (only the label's text in front)
-
+-v- ---------------LSM v2.38 - 2025-11-12--------------------------------------------------------------------------- -v-
 [WORKING ON]
---#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
---Manual call via API function lib.UpdateIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
---lib.UpdateIconsPath(comboBox, control, data)
-
---#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
---Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
---> checkFunc(comboBox, control, data)
---Manual call via API function lib.UpdateEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
---lib.UpdateEntryPath(comboBox, control, data, checkFunc)
+#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
 
 
 [Fixed]
@@ -26,16 +15,17 @@
 #2025_55 Radiobutton [ ] part clicked in a contextmenu's submenu raises a lua error user:/AddOns/LibScrollableMenu/classes/buttonGroup_class.lua:171: attempt to index a nil value
 
 [Added]
-#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a (sub)menu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
--Added options.automaticRefresh
--Added options.automaticSubmenuRefresh
---->  === Dropdown Refresh functions
---		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the normal scrollList should happen, if you click/change any entry's value. This would be needed
---												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
---		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrollList should happen, if you click/change any entry's value. This would be needed
---												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
+--#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
+--> checkFunc(comboBox, control, data)
+--Manual call via API function UpdateCustomScrollableMenuEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
+--UpdateCustomScrollableMenuEntryPath(comboBox, control, data, checkFunc, checkFuncParam1, checkFuncParam2, ...)
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
+--#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Manual call via API function UpdateCustomScrollableMenuEntryIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
+--UpdateCustomScrollableMenuEntryIconsPath(comboBox, control, data)
 #2025_58 API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)
 -->Parameter updateMode can be left empty, then the system will automatically determine if a submenu exists and the item belongs to that, and refresh that,
 --or it will update the mainmenu if it exists.
@@ -45,8 +35,11 @@
 --->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
 ---Parameter comboBox is optional
 RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
-#2025_59 Added API function IsCustomScrollableContextMenuShown
+#2025_59 Added API function IsCustomScrollableContextMenuShown()
 --Returns boolean true/false if any LSM context menu is currently showing it's dropdown
+#2025_60 Added API function IsCustomScrollableMenuShown()
+--Returns boolean true/false if any LSM menu is currently showing it's dropdown (including any LSM ContextMenu!)
+
 
 
 -v- ---------------LSM v2.37 - 2025-09-21--------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,4 +1,22 @@
--v- ---------------LSM v2.38 - 2025-10-21--------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.38 - 2025-10-23--------------------------------------------------------------------------- -v-
+[KNOWN PROBLEMS]
+#2025_48 Search header is not searching an editBox's text or a slider's balue (only the label's text in front)
+
+[WORKING ON]
+#2025_44 New API function lib.OnEntryCallbackUpdateIcons to check from submenu up to main menu if any icon needs an update at the current path.
+--> todo: Automatically called if an entry's data contains data.recursiveIconUpdate = true
+
+[Fixed]
+#2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner == LSM menu should take place then to suppress the close of the menu?
+#2025_47 Clicking a scrollbar at a contextmenu (submenu) will close the contextmenu (submenu)
+#2025_49 Editbox clicked at context menu's submenu will close the contextmenu
+#2025_50 Slider  clicked at context menu's submenu will close the contextmenu
+#2025_51 MultiIcon clicked at context menu's submenu will close the contextmenu
+#2025_52 Checkbox [ ] part clicked in a submenu closes the submenu
+#2025_53 Checkbox label or [ ] part clicked in a contextmenu's submenu closes the submenu
+#2025_54 Radiobutton label or [ ] part clicked in a contextmenu's submenu closes the submenu
+#2025_55 Radiobutton [ ] part clicked in a contextmenu's submenu raises a lua error user:/AddOns/LibScrollableMenu/classes/buttonGroup_class.lua:171: attempt to index a nil value
+
 [Added]
 #2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
@@ -10,7 +28,9 @@
 --		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrolllist should happen, if you click/change any entry's value. This would be needed
 --												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 #2025_44 Added API function lib.UpdateIconsRecursively(comboBox, rowControl, optional: data) Update the path upwards from submenu's rowControl to the parent menus and refresh the icons at the entries. Can be called manually from a callback of any submenu entry e.g. or will be automatically called if the submenu's entry data.recursiveIconUpdate == true
+-->2nd part entry data.recursiveIconUpdate == true is still open -> 20251023
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
+
 
 
 -v- ---------------LSM v2.37 - 2025-09-21--------------------------------------------------------------------------- -v-

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,6 +1,7 @@
 -v- ---------------LSM v2.38 - 2025-11-14--------------------------------------------------------------------------- -v-
 [WORKING ON]
-#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
+#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(LSM_comboBox, selectedContextMenuItem, openingMenusEntries), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
+--->If it's a fucntion you can also specify doNotFilterEntryTypes = table or function returning a table of LSM entryTypes which should be prefiltering the current list, before the doNotFilter function is executed on them (e.g. { LSM_ENTRY_TYPE_CHECKBOX } to only prefilter checkbox entries of the current list)
 
 
 [Fixed]
@@ -40,6 +41,10 @@ RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
 --Returns boolean true/false if any LSM context menu is currently showing it's dropdown
 #2025_60 Added API function IsCustomScrollableMenuShown()
 --Returns boolean true/false if any LSM menu is currently showing it's dropdown (including any LSM ContextMenu!)
+
+[Changed]
+#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(LSM_comboBox, selectedContextMenuItem, openingMenusEntries), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
+--->If it's a fucntion you can also specify doNotFilterEntryTypes = table or function returning a table of LSM entryTypes which should be prefiltering the current list, before the doNotFilter function is executed on them (e.g. { LSM_ENTRY_TYPE_CHECKBOX } to only prefilter checkbox entries of the current list)
 
 
 

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,11 +1,12 @@
--v- ---------------LSM v2.38 - 2025-11-12--------------------------------------------------------------------------- -v-
+-v- ---------------LSM v2.38 - 2025-11-14--------------------------------------------------------------------------- -v-
 [WORKING ON]
-#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
+#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
 
 
 [Fixed]
 #2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner == LSM menu should take place then to suppress the close of the menu?
 #2025_47 Clicking a scrollbar at a contextmenu (submenu) will close the contextmenu (submenu)
+#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
 #2025_49 Editbox clicked at context menu's submenu will close the contextmenu
 #2025_50 Slider  clicked at context menu's submenu will close the contextmenu
 #2025_51 MultiIcon clicked at context menu's submenu will close the contextmenu

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,8 +1,5 @@
 -v- ---------------LSM v2.38 - 2025-11-14--------------------------------------------------------------------------- -v-
 [WORKING ON]
-#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(LSM_comboBox, selectedContextMenuItem, openingMenusEntries), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
---->If it's a fucntion you can also specify doNotFilterEntryTypes = table or function returning a table of LSM entryTypes which should be prefiltering the current list, before the doNotFilter function is executed on them (e.g. { LSM_ENTRY_TYPE_CHECKBOX } to only prefilter checkbox entries of the current list)
-
 
 [Fixed]
 #2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner == LSM menu should take place then to suppress the close of the menu?
@@ -25,7 +22,7 @@
 --Manual call via API function UpdateCustomScrollableMenuEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
 --UpdateCustomScrollableMenuEntryPath(comboBox, control, data, checkFunc, checkFuncParam1, checkFuncParam2, ...)
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
---#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
 --Manual call via API function UpdateCustomScrollableMenuEntryIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
 --UpdateCustomScrollableMenuEntryIconsPath(comboBox, control, data)
 #2025_58 API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)

--- a/LibScrollableMenu/classes/buttonGroup_class.lua
+++ b/LibScrollableMenu/classes/buttonGroup_class.lua
@@ -16,7 +16,7 @@ if not lib then return end
 --------------------------------------------------------------------
 -- Locals
 --------------------------------------------------------------------
-
+local tos = tostring
 
 --------------------------------------------------------------------
 --Library classes
@@ -32,7 +32,7 @@ local entryTypeConstants = constants.entryTypes
 
 
 local libUtil = lib.Util
---local getControlName = libUtil.getControlName
+local getControlName = libUtil.getControlName
 local checkIfContextMenuOpenedButOtherControlWasClicked = libUtil.checkIfContextMenuOpenedButOtherControlWasClicked
 local hideTooltip = libUtil.hideTooltip
 
@@ -131,13 +131,26 @@ function buttonGroupClass:SetButtonState(button, clickedButton, enabled, ignoreC
 end
 
 function buttonGroupClass:HandleClick(control, buttonId, ignoreCallback)
---d("HandleClick - button: " .. getControlName(control))
+	local doDebugNow = false
+	if doDebugNow then d("HandleClick - button: " .. getControlName(control)) end
 	if not self.m_enabled or self.m_clickedButton == control then
+		if doDebugNow then d("<self.m_clickedButton == control: " .. tos(self.m_clickedButton == control)) end
 		return
 	end
 
 	-- Can't click disabled buttons
 	local controlData = self.m_buttons[control]
+	if doDebugNow then
+		LSM_Debug = LSM_Debug or {}
+		LSM_Debug._buttonGroupClass_HandleClick = LSM_Debug._buttonGroupClass_HandleClick or {}
+		LSM_Debug._buttonGroupClass_HandleClick[control] = {
+			self = self,
+			control = control,
+			buttonId = buttonId,
+			ignoreCallback = ignoreCallback,
+			controlData = controlData,
+		}
+	end
 	if controlData and not controlData.isValidOption then
 		return
 	end
@@ -151,14 +164,14 @@ function buttonGroupClass:HandleClick(control, buttonId, ignoreCallback)
 		-- Set all buttons in the group to unpressed, and unlocked.
 		-- If the button is disabled externally (maybe it isn't a valid option at this time)
 		-- then set it to unpressed, but disabled.
---d(">>> for k, v in pairs(self.buttons) -> SetButtonState")
+		--d(">>> for k, v in pairs(self.buttons) -> SetButtonState")
 		for k, v in pairs(self.m_buttons) do
-		--	self:SetButtonState(k, nil, v.isValidOption)
+			--	self:SetButtonState(k, nil, v.isValidOption)
 			self:SetButtonState(k, control, v.isValidOption, ignoreCallback)
 		end
 
 		-- Set the clicked button to pressed and lock it down (so that it stays pressed.)
---		control:SetState(BSTATE_PRESSED, true)
+		--		control:SetState(BSTATE_PRESSED, true)
 		local previousControl = self.m_clickedButton
 		self.m_clickedButton = control
 
@@ -168,7 +181,7 @@ function buttonGroupClass:HandleClick(control, buttonId, ignoreCallback)
 		end
 	end
 
-	if controlData.originalHandler then
+	if controlData and controlData.originalHandler then --#2025_55 Radiobutton [ ] part clicked in a contextmenu's submenu raises a lua error user:/AddOns/LibScrollableMenu/classes/buttonGroup_class.lua:171: attempt to index a nil value
 		controlData.originalHandler(control, buttonId)
 	end
 end

--- a/LibScrollableMenu/classes/comboBox_base.lua
+++ b/LibScrollableMenu/classes/comboBox_base.lua
@@ -509,9 +509,16 @@ local function updateIcons(control, data)
 	local anyIconWasAdded = false
 	local iconDataType = iconData ~= nil and type(iconData) or nil
 	if iconDataType ~= nil then
+--d("[LSM]updateIcons - iconData found")
 		if iconDataType ~= 'table' then
 			--If only a "any.dds" texture path or a function returning this was passed in
 			iconData = { [1] = { iconTexture = iconData } }
+		else
+			--#2025_43 Check if icon table got just 1 entry, directly starting with iconTexture etc. (wrong formatted)
+			if iconData.iconTexture ~= nil then
+				local iconDataFixed = { [1] = ZO_ShallowTableCopy(iconData) }
+				iconData = iconDataFixed
+			end
 		end
 		for iconIdx, singleIconData in ipairs(iconData) do
 			local l_anyIconWasAdded, l_iconWidth, l_iconHeight = updateIcon(control, data, iconIdx, singleIconData, multiIconCtrl, parentHeight)

--- a/LibScrollableMenu/classes/comboBox_base.lua
+++ b/LibScrollableMenu/classes/comboBox_base.lua
@@ -520,6 +520,7 @@ local function updateIcons(control, data)
 				iconData = iconDataFixed
 			end
 		end
+
 		for iconIdx, singleIconData in ipairs(iconData) do
 			local l_anyIconWasAdded, l_iconWidth, l_iconHeight = updateIcon(control, data, iconIdx, singleIconData, multiIconCtrl, parentHeight)
 			if l_anyIconWasAdded == true then
@@ -536,11 +537,16 @@ local function updateIcons(control, data)
 	multiIconCtrl:SetDrawLevel(10)
 
 	if anyIconWasAdded then
-		multiIconCtrl:SetHandler("OnMouseEnter", function(...)
-			ZO_Options_OnMouseEnter(...)
-			InformationTooltipTopLevel:BringWindowToTop()
-		end)
-		multiIconCtrl:SetHandler("OnMouseExit", ZO_Options_OnMouseExit)
+--d(">icons were added")
+		if multiIconCtrl:GetHandler("OnMouseEnter") == nil then
+			multiIconCtrl:SetHandler("OnMouseEnter", function(...)
+				ZO_Options_OnMouseEnter(...)
+				InformationTooltipTopLevel:BringWindowToTop()
+			end)
+		end
+		if multiIconCtrl:GetHandler("OnMouseExit") == nil then
+			multiIconCtrl:SetHandler("OnMouseExit", ZO_Options_OnMouseExit)
+		end
 
 		multiIconCtrl:Show() --todo 20240527 Make that dependent on getValueOrCallback(data.enabled, data) ?! And update via multiIconCtrl:Hide()/multiIconCtrl:Show() on each show of menu!
 	end

--- a/LibScrollableMenu/classes/comboBox_base.lua
+++ b/LibScrollableMenu/classes/comboBox_base.lua
@@ -2466,7 +2466,13 @@ d(">enabled: " .. tos(data.enabled))
 
 		--EditBox data was specified too? Custom font, height, width, etc.
 		local editBoxData = getEditBoxData(control, data)
+		--Add the editBoxCtrl to the editBoxData, as reference for the text search functionalities
+		editBoxData._EditBoxCtrl = editBoxCtrl
 		control.editBoxData = editBoxData
+		local editBoxTemplate = data.editBoxTemplate or editBoxData.editBoxTemplate
+		if editBoxTemplate then
+			ApplyTemplateToControl(control, editBoxTemplate)
+		end
 		processEditBoxData(control)
 
 		local isEnabled = data.enabled
@@ -2474,6 +2480,8 @@ d(">enabled: " .. tos(data.enabled))
 			isEnabled = control:IsEnabled()
 		end
 		editBoxCtrl:SetMouseEnabled(isEnabled)
+
+		self:UpdateHighlightTemplate(control, data, nil, nil)
 	end
 
 	--Setup row function: LSM_ENTRY_TYPE_SLIDER
@@ -2496,7 +2504,13 @@ d(">enabled: " .. tos(data.enabled))
 
 		--EditBox data was specified too? Custom font, height, width, etc.
 		local sliderData = getSliderData(control, data)
+		--Add the sliderCtrl to the sliderData, as reference for the text search functionalities
+		sliderData._SliderCtrl = sliderCtrl
 		control.sliderData = sliderData
+		local sliderTemplate = data.sliderTemplate or sliderData.sliderTemplate
+		if sliderTemplate then
+			ApplyTemplateToControl(control, sliderTemplate)
+		end
 		processSliderData(control)
 
 		local isEnabled = data.enabled
@@ -2504,6 +2518,8 @@ d(">enabled: " .. tos(data.enabled))
 			isEnabled = control:IsEnabled()
 		end
 		sliderCtrl:SetMouseEnabled(isEnabled)
+
+		self:UpdateHighlightTemplate(control, data, nil, nil)
 	end
 end
 

--- a/LibScrollableMenu/classes/comboBox_base.lua
+++ b/LibScrollableMenu/classes/comboBox_base.lua
@@ -1234,7 +1234,7 @@ function comboBox_base:HiddenForReasons(button, isMouseOverOwningDropdown)
 
 	if isOwnedByComboBox == true or wasTextSearchContextMenuEntryClicked == true or wasFilterHeaderClicked == true or wasEditBoxClickedAtContextMenu == true or wasSliderClickedAtContextMenu == true or wasMultiIconClickedAtContextMenu == true then
 		if doDebugNow then  d(">>isEmpty: " ..tos(ZO_IsTableEmpty(mocEntry)) .. ", enabled: " ..tos(mocEntry.enabled) .. ", mouseEnabled: " .. tos(mocEntry.IsMouseEnabled and mocEntry:IsMouseEnabled())) end
-		if ZO_IsTableEmpty(mocEntry) or (mocEntry.enabled and mocEntry.enabled ~= false) or (mocEntry.IsMouseEnabled and mocEntry:IsMouseEnabled()) then
+		if type(mocEntry) == "table" and (ZO_IsTableEmpty(mocEntry) or (mocEntry.enabled and mocEntry.enabled ~= false) or (mocEntry.IsMouseEnabled and mocEntry:IsMouseEnabled())) then
 			if button == MOUSE_BUTTON_INDEX_LEFT then
 				--do not close or keep open based on clicked entry but do checks in contextMenuClass:GetHiddenForReasons instead
 				if isContextMenuVisible == true then

--- a/LibScrollableMenu/classes/comboBox_class.lua
+++ b/LibScrollableMenu/classes/comboBox_class.lua
@@ -234,6 +234,15 @@ function comboBoxClass:SetFilterString(filterBox, newText)
 	self:UpdateResults(true)
 end
 
+--#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+function comboBoxClass:IsAutomaticRefreshEnabled()
+	local options = self:GetOptions()
+	local automaticRefreshEnabled = (options and getValueOrCallback(options.automaticRefresh, options)) or false
+--d(debugPrefix .. "comboBoxClass:IsAutomaticRefreshEnabled - automaticRefreshEnabled: " ..tos(automaticRefreshEnabled))
+	return automaticRefreshEnabled
+end
+
+
 function comboBoxClass:SetDefaults()
 	self.defaults = {}
 	for k, v in pairs(comboBoxDefaults) do

--- a/LibScrollableMenu/classes/comboBox_class.lua
+++ b/LibScrollableMenu/classes/comboBox_class.lua
@@ -237,9 +237,12 @@ end
 --#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 function comboBoxClass:IsAutomaticRefreshEnabled()
 	local options = self:GetOptions()
-	local automaticRefreshEnabled = (options and getValueOrCallback(options.automaticRefresh, options)) or false
---d(debugPrefix .. "comboBoxClass:IsAutomaticRefreshEnabled - automaticRefreshEnabled: " ..tos(automaticRefreshEnabled))
-	return automaticRefreshEnabled
+	if options ~= nil then
+		local automaticRefreshEnabled = (getValueOrCallback(options.automaticRefresh, options)) or false
+		local automaticSubmenuRefreshEnabled = (getValueOrCallback(options.automaticSubmenuRefresh, options)) or false
+		--d(debugPrefix .. "comboBoxClass:IsAutomaticRefreshEnabled - automaticRefreshEnabled: " ..tos(automaticRefreshEnabled))
+		return automaticRefreshEnabled, automaticSubmenuRefreshEnabled
+	end
 end
 
 

--- a/LibScrollableMenu/classes/contextMenu_class.lua
+++ b/LibScrollableMenu/classes/contextMenu_class.lua
@@ -270,33 +270,75 @@ function contextMenuClass:ShowContextMenu(parentControl)
 end
 
 --#2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
-local contextMenuCallbacksRegistered = {}
-lib.contextMenuCallbacksRegistered = contextMenuCallbacksRegistered
 function contextMenuClass:RegisterSpecialCallback(uniqueAddonName, callbackName, specialCallbackData)
-	if uniqueAddonName == nil or uniqueAddonName == "" or callbackName == nil or callbackName == ""
-			or specialCallbackData == nil or type(specialCallbackData[callbackName] ~= "function") then return false end
+	--d("[LSM]contextMenuClass:RegisterSpecialCallback - uniqueAddonName: " .. tos(uniqueAddonName) ..", callbackName: " .. tos(callbackName))
+	if uniqueAddonName == nil or uniqueAddonName == "" or callbackName == nil or callbackName == "" then return false end
+	if specialCallbackData == nil or type(specialCallbackData[callbackName]) ~= "function" then return false end
 
+	local contextMenuCallbacksRegistered = lib.contextMenuCallbacksRegistered
 	--Register the callback(s), in order of appearance (1st addon registering a callback should be kept first in the table)
 	local counterAddons = #contextMenuCallbacksRegistered + 1
+--d(">counterAddons: " .. tos(counterAddons))
 	contextMenuCallbacksRegistered[counterAddons] = {}
 	contextMenuCallbacksRegistered[counterAddons][uniqueAddonName] = {}
-	contextMenuCallbacksRegistered[counterAddons][uniqueAddonName][callbackName] = { callback = specialCallbackData[callbackName], specialData = specialCallbackData }
-
+	contextMenuCallbacksRegistered[counterAddons][uniqueAddonName][callbackName] = {
+	callback = 		specialCallbackData[callbackName],
+	specialData = 	specialCallbackData
+	}
 	return true
 end
 
+function contextMenuClass:UnregisterSpecialCallback(uniqueAddonName, callbackName)
+	if uniqueAddonName == nil or uniqueAddonName == "" then return false end
+
+	local toDeleteIndices = {}
+	local contextMenuCallbacksRegistered = lib.contextMenuCallbacksRegistered
+	for idx, registeredAddons in ipairs(contextMenuCallbacksRegistered) do
+		for loopedUniqueAddonName, registeredCallbacks in pairs(registeredAddons) do
+			if loopedUniqueAddonName == uniqueAddonName then
+				--No callbackname provided, means: delete all
+				if callbackName == nil then
+	d(">no callback specified, deleting all contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "]")
+					registeredCallbacks = nil
+					toDeleteIndices[idx] = true
+				else
+					--Remove the callbacks of that uniqueAddonName entry
+					if registeredCallbacks[callbackName] ~= nil then
+	d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "][" .. tos(callbackName) .. "]")
+						registeredCallbacks[callbackName] = nil
+						--Check if any other callback is still registered there, else remove the total registered callbacks entry
+						if NonContiguousCount(registeredCallbacks) == 0 then
+	d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "]")
+							registeredCallbacks = nil
+							toDeleteIndices[idx] = true
+						end
+					end
+				end
+			end
+		end
+	end
+
+	if NonContiguousCount(toDeleteIndices) > 0 then
+		for idx, doDelete in pairs(toDeleteIndices) do
+d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."]")
+			lib.contextMenuCallbacksRegistered[idx] = nil
+		end
+	end
+end
+
 function contextMenuClass:RunSpecialCallback(callbackName)
-d("[LSM]contextMenuClass:RunSpecialCallback - callbackName: " .. tos(callbackName))
+--d("[LSM]contextMenuClass:RunSpecialCallback - callbackName: " .. tos(callbackName))
+	local contextMenuCallbacksRegistered = lib.contextMenuCallbacksRegistered
 	if callbackName == nil or callbackName == "" or #contextMenuCallbacksRegistered == 0 then return end
 
 	local retVar = false
 	local openingControl = self.openingControl
 	--Execute the callbacks like onShowCallback or onHideCallback now
 	for _, registeredAddons in ipairs(contextMenuCallbacksRegistered) do
-		for uniqueAddonName, registeredCallbacks in ipairs(registeredAddons) do
+		for uniqueAddonName, registeredCallbacks in pairs(registeredAddons) do
 			local callbackEntry = registeredCallbacks[callbackName]
 			if callbackEntry ~= nil and callbackEntry.callback ~= nil then
-d(">executing callback for registered addon: " .. tos(uniqueAddonName))
+--d(">executing callback for registered addon: " .. tos(uniqueAddonName))
 				local l_retVar = callbackEntry.callback(self, openingControl, callbackEntry.specialData)
 				if not retVar then retVar = l_retVar end
 			end

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -1761,13 +1761,23 @@ function dropdownClass:HideDropdown()
 end
 
 --#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+function dropdownClass:IsAutomaticRefreshEnabled()
+	if self.m_comboBox then
+		return self.m_comboBox:IsAutomaticRefreshEnabled()
+	end
+end
+
 function dropdownClass:SubmenuOrCurrentListRefresh(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 192, tos(getControlName(control))) end
 
 	if not self.owner then return end
 	local comboBox = self.m_comboBox
 	if not comboBox or not comboBox:IsDropdownVisible() then return end
-d("[LSM]dropdownClass:SubmenuOrCurrentListRefresh")
+
+	--Check if the automatic update is enabled via the options
+	if not self:IsAutomaticRefreshEnabled() then return end
+
+	--d("[LSM]dropdownClass:SubmenuOrCurrentListRefresh")
 	if not self.m_parentMenu then --dropdown got no submenu? Refresh current scrollList
 		zo_callLater(function() --delay the update of the entries a bit so all values have been updated properly before
 			comboBox:Show()

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -479,7 +479,6 @@ local function onMouseUp(control, data, hasSubmenu)
 	dropdown:Narrate("OnEntrySelected", control, data, hasSubmenu)
 
 	hideTooltip(control)
-d("[LSM]onMouseUp -> dropdown:SubmenuRefresh")
 	dropdown:SubmenuRefresh(control) --#2025_42
 	return dropdown
 end
@@ -1764,6 +1763,9 @@ end
 --#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 function dropdownClass:SubmenuRefresh(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 192, tos(getControlName(control))) end
+
+	if not self.owner or not self.m_parentMenu then return end --dropdown got no submenu?
+
 	local owner = (control ~= nil and control.m_owner) or self.owner
 	if owner ~= nil and owner.openingControl ~= nil and self.m_comboBox:IsDropdownVisible() then
 		--Reshow the whole submenu of the openingControl again, to update all enabled and checked states of the entries,

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -1609,11 +1609,14 @@ end
 function dropdownClass:OnHide(formattedEventName)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 79) end
 
-	--todo #2025_45 Call special contextMenu OnClose callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.OnCloseCallback)
-d("[LSM]dropdownClass:OnHide - isContextMenu: " .. tos(self.isContextMenu))
-	if self.isContextMenu == true then
-		if self.owner then
-			self.owner:RunSpecialCallback("onHideCallback")
+	--#2025_45 Call special contextMenu OnClose callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.OnCloseCallback)
+	local comboBox = self.m_comboBox
+	local isContextMenu = comboBox and comboBox.isContextMenu or false
+--d("[LSM]dropdownClass:OnHide - isContextMenu: " .. tos(isContextMenu))
+	if isContextMenu == true then
+		local owner = self.owner
+		if owner and owner.RunSpecialCallback then --Only contextMenu_Class uses that function
+			owner:RunSpecialCallback("onHideCallback")
 		end
 	end
 

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -197,7 +197,8 @@ local function updateSubmenuIcons(selfVar, control)
 	end
 end
 
---#2025_44 Recursively check if any icon on the current submenu path up to main menu needs an update
+--#2025_44 Recursively check if any icon on the current submenu path up to main menu needs an update. Manual call via API
+--or automatic call if submenuEntry.recursiveIconUpdate == true
 local function onEntryCallbackUpdateIcons(selfVar, control, data)
 --d("[LSM]UpdateIconsRecursively - control: " .. tos(getControlName(control)))
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 193, tos(getControlName(control))) end
@@ -1436,6 +1437,7 @@ end
 
 --Called from XML virtual template <Control name="ZO_ComboBoxEntry" -> "OnMouseUp" -> ZO_ComboBoxDropdown_Keyboard.OnEntryMouseUp
 -->And in LSM code from XML virtual template LibScrollableMenu_ComboBoxEntry_Behavior -> "OnMouseUp" -> dropdownClass:OnEntryMouseUp
+--> #2025_46 This method is not called as the control is mouseEnabled false!
 function dropdownClass:OnEntryMouseUp(control, button, upInside, ignoreHandler, ctrl, alt, shift, lsmEntryType)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 71, tos(getControlName(control)), tos(button), tos(upInside)) end
 --d(debugPrefix .."dropdownClass:OnEntryMouseUp-"  .. tos(getControlName(control)) ..", button: " .. tos(button) .. ", upInside: " .. tos(upInside) .. ", lsmEntryType: " .. tos(lsmEntryType))
@@ -1449,8 +1451,7 @@ function dropdownClass:OnEntryMouseUp(control, button, upInside, ignoreHandler, 
 		local data = getControlData(control)
 		--	local comboBox = getComboBox(control, true)
 		local comboBox = control.m_owner
-
-		--[[
+--[[
 LSM_Debug = LSM_Debug or {}
 LSM_Debug._OnEntryMouseUp = LSM_Debug._OnEntryMouseUp or {}
 LSM_Debug._OnEntryMouseUp[#LSM_Debug._OnEntryMouseUp +1] = {

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -479,6 +479,8 @@ local function onMouseUp(control, data, hasSubmenu)
 	dropdown:Narrate("OnEntrySelected", control, data, hasSubmenu)
 
 	hideTooltip(control)
+d("[LSM]onMouseUp -> dropdown:SubmenuRefresh")
+	dropdown:SubmenuRefresh(control) --#2025_42
 	return dropdown
 end
 
@@ -1758,6 +1760,20 @@ function dropdownClass:HideDropdown()
 		self.owner:HideDropdown()
 	end
 end
+
+--#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+function dropdownClass:SubmenuRefresh(control)
+	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 192, tos(getControlName(control))) end
+	local owner = (control ~= nil and control.m_owner) or self.owner
+	if owner ~= nil and owner.openingControl ~= nil and self.m_comboBox:IsDropdownVisible() then
+		--Reshow the whole submenu of the openingControl again, to update all enabled and checked states of the entries,
+		--if any other entry was clicked
+		-- Must clear now. Otherwise, moving onto a submenu will close it from exiting previous row.
+		clearTimeout()
+		self:ShowSubmenu(owner.openingControl)
+	end
+end
+
 
 --Called from checkNormalOnMouseEnterTasks, and dropdownClass:OnEntryMouseUp -> dropdownClass:OnEntrySelected -> --self(= dropdownClass).owner(= comboBoxClass of parentMenu?!):SetSelected -> self(comboBoxClass):SelectItem -> self.m_dropdownObject(dropdownClass):Refresh()
 -->Needed to make multiselection for submenus work! Checked scrollControl must be the one of the submenu and not the parentMenu's!

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -1769,23 +1769,23 @@ end
 
 function dropdownClass:SubmenuOrCurrentListRefresh(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 192, tos(getControlName(control))) end
-
-	if not self.owner then return end
 	local comboBox = self.m_comboBox
 	if not comboBox or not comboBox:IsDropdownVisible() then return end
 
 	--Check if the automatic update is enabled via the options
-	if not self:IsAutomaticRefreshEnabled() then return end
+	local automaticRefresh, automaticSubmenuRefresh = self:IsAutomaticRefreshEnabled()
+--d("[LSM]dropdownClass:SubmenuOrCurrentListRefresh - automaticRefresh: " .. tos(automaticRefresh) .. ", automaticSubmenuRefresh: " .. tos(automaticSubmenuRefresh))
 
-	--d("[LSM]dropdownClass:SubmenuOrCurrentListRefresh")
-	if not self.m_parentMenu then --dropdown got no submenu? Refresh current scrollList
+	if automaticRefresh == true and not self.m_parentMenu then --dropdown got no submenu? Refresh current scrollList
+--d(">refreshing menu")
 		zo_callLater(function() --delay the update of the entries a bit so all values have been updated properly before
 			comboBox:Show()
 		end, 25)
-	else
+	elseif automaticSubmenuRefresh == true then
 		--Submenu refresh
 		local owner = (control ~= nil and control.m_owner) or self.owner
 		if owner ~= nil and owner.openingControl ~= nil then
+--d(">refreshing submenu")
 			--Reshow the whole submenu of the openingControl again, to update all enabled and checked states of the entries,
 			--if any other entry was clicked
 			-- Must clear now. Otherwise, moving onto a submenu will close it from exiting previous row.

--- a/LibScrollableMenu/code/LSM_Util.lua
+++ b/LibScrollableMenu/code/LSM_Util.lua
@@ -892,6 +892,15 @@ end
 --------------------------------------------------------------------
 -- Dropdown / combobox hidden checks
 --------------------------------------------------------------------
+--#2025_47 Check if a scrollbar, up or down button is clicked
+function libUtil.isScrollBarClicked(scrollCtrl, compareCtrl)
+	if scrollCtrl == nil or compareCtrl == nil or scrollCtrl.scrollbar == nil then return false end
+	if scrollCtrl.scrollbar == compareCtrl then return true end
+	if scrollCtrl.upButton and scrollCtrl.upButton == compareCtrl then return true end
+	if scrollCtrl.downButton and scrollCtrl.downButton == compareCtrl then return true end
+	return false
+end
+
 --20250309 #2025_13 If the last comboBox_base:HiddenForReasons call closed an open contextMenu with multiSelect enabled, and we clicked on an LSM entry of another non-contextmenu
 --to close it, then just exit here and do not select the clicked entry
 function libUtil.checkNextOnEntryMouseUpShouldExecute()

--- a/LibScrollableMenu/code/LSM_Util.lua
+++ b/LibScrollableMenu/code/LSM_Util.lua
@@ -79,11 +79,20 @@ local alreadyCheckedSubmenuOpeningItems = {}
 --------------------------------------------------------------------
 -- Controls
 --------------------------------------------------------------------
+local controlNameCache = lib.Debug.controlNameCache --Cache already determined control names, unless they are nil
+
 function libUtil.getControlName(control, alternativeControl)
+	--Check if cached controlName exists
+	if control ~= nil and controlNameCache[control] ~= nil then return controlNameCache[control] end
+	if alternativeControl ~= nil and controlNameCache[alternativeControl] ~= nil then return controlNameCache[alternativeControl]  end
+
+	--Get controlName and cache it if found
 	local ctrlName = control ~= nil and (control.name or (control.GetName ~= nil and control:GetName()))
 	if ctrlName == nil and alternativeControl ~= nil then
 		ctrlName = (alternativeControl.name or (alternativeControl.GetName ~= nil and alternativeControl:GetName()))
+		if ctrlName ~= nil then controlNameCache[alternativeControl] = ctrlName end
 	end
+	if control ~= nil and ctrlName ~= nil then controlNameCache[control] = ctrlName end
 	ctrlName = ctrlName or "n/a"
 	return ctrlName
 end

--- a/LibScrollableMenu/code/LSM_Util.lua
+++ b/LibScrollableMenu/code/LSM_Util.lua
@@ -151,7 +151,7 @@ local getDataSource = libUtil.getDataSource
 -- >> data, dataEntry
 function libUtil.getControlData(control)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 28, tos(getControlName(control))) end
-	local data = control.m_sortedItems or control.m_data
+	local data = control.m_sortedItems or control.m_data or control
 
 	return getDataSource(data)
 end

--- a/LibScrollableMenu/code/LSM_Util.lua
+++ b/LibScrollableMenu/code/LSM_Util.lua
@@ -225,7 +225,7 @@ function libUtil.recursiveOverEntries(entry, comboBox, callback, ...)
 	]]
 
 	if endlessLoopPreventionCounter >= 5000 then
-d("[LSM]recursiveOverEntries - EEEEEEEEEEEEEEE   --ABORT ENDLESS LOOP--   EEEEEEEEEEEEEE")
+d("["..MAJOR.."]recursiveOverEntries - EEEEEEEEEEEEEEE   --ABORT ENDLESS LOOP--   EEEEEEEEEEEEEE")
 		return
 	end
 

--- a/LibScrollableMenu/code/LSM_Util.lua
+++ b/LibScrollableMenu/code/LSM_Util.lua
@@ -961,7 +961,7 @@ function libUtil.checkIfHiddenForReasons(selfVar, button, isContextMenu, owningW
 					returnValue = true
 				else
 					--Is the mocEntry an empty table (something else was clicked than a LSM entry)
-					if ZO_IsTableEmpty(entry) then
+					if type(entry) == "table" and ZO_IsTableEmpty(entry) then
 						if doDebugNow then d("<1ZO_IsTableEmpty(entry) -> true") end
 						returnValue = true
 					else
@@ -1012,7 +1012,7 @@ function libUtil.checkIfHiddenForReasons(selfVar, button, isContextMenu, owningW
 				clickedNoEntry = true
 			else
 				--Is the mocEntry an empty table (something else was clicked than a LSM entry)
-				if ZO_IsTableEmpty(entry) then
+				if type(entry) == "table" and ZO_IsTableEmpty(entry) then
 					if doDebugNow then d("<2 ZO_IsTableEmpty(entry) -> true; ctxtDropdown==mocCtrl.dropdown: " ..tos(contextMenuDropdownObject == mocCtrl.m_dropdownObject) .. "; owningWind==cntxMen: " ..tos(mocCtrl:GetOwningWindow() == g_contextMenu.m_dropdown)) end
 					-- Was e.g. a context menu's submenu search header's editBox or the refresh button left clicked?
 					if mocCtrl then

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -285,7 +285,6 @@ Max error #: 2025_44
 #2025_42 is not working for the icons, they do not update at the submenu/menus
 
 [WORKING ON]
-#2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
 
 [Fixed]
 
@@ -293,6 +292,7 @@ Max error #: 2025_44
 #2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
 #2025_44 New API function lib.OnEntryCallbackUpdateIcons to check from submenu up to main menu if any icon needs an update at the current path. Automatically called if an entry's data contains data.recursiveIconUpdate = true
+#2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
 
 [Changed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -279,18 +279,20 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 ---------------------------------------------------------------
 	CHANGELOG Current version: 2.38 - Updated 2025-10-21
 ---------------------------------------------------------------
-Max error #: 2025_43
+Max error #: 2025_44
 
 [KNOWN PROBLEMS]
 #2025_42 is not working for the icons, they do not update at the submenu/menus
 
 [WORKING ON]
+#2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
 
 [Fixed]
 
 [Added]
 #2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
+#2025_44 New API function lib.OnEntryCallbackUpdateIcons to check from submenu up to main menu if any icon needs an update at the current path. Automatically called if an entry's data contains data.recursiveIconUpdate = true
 
 [Changed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -277,21 +277,31 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.38 - Updated 2025-10-21
+	CHANGELOG Current version: 2.38 - Updated 2025-10-23
 ---------------------------------------------------------------
-Max error #: 2025_44
+Max error #: 2025_55
 
 [KNOWN PROBLEMS]
-#2025_42 is not working for the icons, they do not update at the submenu/menus
+#2025_48 Search header is not searching an editBox's text or a slider's balue (only the label's text in front)
 
 [WORKING ON]
+#2025_44 New API function lib.OnEntryCallbackUpdateIcons to check from submenu up to main menu if any icon needs an update at the current path.
+--> todo: Automatically called if an entry's data contains data.recursiveIconUpdate = true
 
 [Fixed]
+#2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner == LSM menu should take place then to suppress the close of the menu?
+#2025_47 Clicking a scrollbar at a contextmenu (submenu) will close the contextmenu (submenu)
+#2025_49 Editbox clicked at context menu's submenu will close the contextmenu
+#2025_50 Slider  clicked at context menu's submenu will close the contextmenu
+#2025_51 MultiIcon clicked at context menu's submenu will close the contextmenu
+#2025_52 Checkbox [ ] part clicked in a submenu closes the submenu
+#2025_53 Checkbox label or [ ] part clicked in a contextmenu's submenu closes the submenu
+#2025_54 Radiobutton label or [ ] part clicked in a contextmenu's submenu closes the submenu
+#2025_55 Radiobutton [ ] part clicked in a contextmenu's submenu raises a lua error user:/AddOns/LibScrollableMenu/classes/buttonGroup_class.lua:171: attempt to index a nil value
 
 [Added]
 #2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
-#2025_44 New API function lib.OnEntryCallbackUpdateIcons to check from submenu up to main menu if any icon needs an update at the current path. Automatically called if an entry's data contains data.recursiveIconUpdate = true
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
 
 [Changed]

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -147,11 +147,15 @@ function lib.XML.XMLButtonOnInitialize(control, entryType)
 				if checkNextOnEntryMouseUpShouldExecute() then return end
 
 				local data = getControlData(parent)
-				playSelectedSoundCheck(parent.m_dropdownObject, data.entryType)
+				local dropdown = parent.m_dropdownObject
+				playSelectedSoundCheck(dropdown, data.entryType)
 
 				local onClickedHandler = control:GetHandler('OnClicked')
 				if onClickedHandler then
 					onClickedHandler(control, buttonId)
+
+					d("[LSM]lib.XML.XMLButtonOnInitialize -> Checkbox/RadioButton dropdown:SubmenuRefresh")
+					dropdown:SubmenuRefresh(control) --#2025_42
 				end
 
 			elseif buttonId == MOUSE_BUTTON_INDEX_RIGHT then
@@ -274,24 +278,18 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.37 - Updated 2025-09-21
+	CHANGELOG Current version: 2.38 - Updated 2025-10-21
 ---------------------------------------------------------------
-Max error #: 2025_41
+Max error #: 2025_42
 
 [KNOWN PROBLEMS]
-#2025_41 Slider does not show it's actual value on first open (value set via sliderData.value entry)
 
 [WORKING ON]
+#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 
 [Fixed]
 
 [Added]
--2025_35    Added entryType LSM_ENTRY_TYPE_EDITBOX
--2025_36    Added API function AddCustomScrollableMenuEditBox(text, callback, editBoxData, additionalData)
--2025_37    Added API function AddCustomScrollableMenuRadioButton(text, callback, checked, buttonGroup, additionalData)
--2025_38    Added entryType LSM_ENTRY_TYPE_SLIDER
--2025_39 	Clicking icon in contextmenu's submenu will close the entry as it "get's selected" even though the row got closeOnSelect = false
--2025_41    Added API function AddCustomScrollableMenuSlider(text, callback, sliderData, additionalData)
 
 [Changed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -277,11 +277,11 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.38 - Updated 2025-11-12
+	CHANGELOG Current version: 2.38 - Updated 2025-11-14
 ---------------------------------------------------------------
 Max error #: 2025_61
 
-[FEATURE[
+[FEATURE]
 #2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
 
 [KNOWN PROBLEMS]
@@ -291,12 +291,12 @@ Max error #: 2025_61
 
 
 [WORKING ON]
-#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
 
 
 [Fixed]
 #2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner == LSM menu should take place then to suppress the close of the menu?
 #2025_47 Clicking a scrollbar at a contextmenu (submenu) will close the contextmenu (submenu)
+#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
 #2025_49 Editbox clicked at context menu's submenu will close the contextmenu
 #2025_50 Slider  clicked at context menu's submenu will close the contextmenu
 #2025_51 MultiIcon clicked at context menu's submenu will close the contextmenu

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -277,9 +277,9 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.38 - Updated 2025-10-23
+	CHANGELOG Current version: 2.38 - Updated 2025-11-05
 ---------------------------------------------------------------
-Max error #: 2025_57
+Max error #: 2025_59
 
 [FEATURE[
 #2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
@@ -314,6 +314,17 @@ Max error #: 2025_57
 #2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a (sub)menu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
+#2025_58 API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)
+-->Parameter updateMode can be left empty, then the system will automatically determine if a submenu exists and the item belongs to that, and refresh that,
+--or it will update the mainmenu if it exists.
+--Or you specify one of the following updateModes:
+--->LSM_UPDATE_MODE_MAINMENU	Only update the mainmenu visually
+--->LSM_UPDATE_MODE_SUBMENU		Only update the submenu visually
+--->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
+---Parameter comboBox is optional
+RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
+#2025_59 Added API function IsCustomScrollableContextMenuShown
+--Returns boolean true/false if any LSM context menu is currently showing it's dropdown
 
 [Changed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -279,14 +279,25 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 ---------------------------------------------------------------
 	CHANGELOG Current version: 2.38 - Updated 2025-10-23
 ---------------------------------------------------------------
-Max error #: 2025_55
+Max error #: 2025_57
+
+[FEATURE[
+#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
 
 [KNOWN PROBLEMS]
 #2025_48 Search header is not searching an editBox's text or a slider's balue (only the label's text in front)
 
 [WORKING ON]
-#2025_44 New API function lib.OnEntryCallbackUpdateIcons to check from submenu up to main menu if any icon needs an update at the current path.
---> todo: Automatically called if an entry's data contains data.recursiveIconUpdate = true
+--#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Manual call via API function lib.UpdateIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
+--lib.UpdateIconsPath(comboBox, control, data)
+
+--#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
+--> checkFunc(comboBox, control, data)
+--Manual call via API function lib.UpdateEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
+--lib.UpdateEntryPath(comboBox, control, data, checkFunc)
+
 
 [Fixed]
 #2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner == LSM menu should take place then to suppress the close of the menu?
@@ -300,7 +311,7 @@ Max error #: 2025_55
 #2025_55 Radiobutton [ ] part clicked in a contextmenu's submenu raises a lua error user:/AddOns/LibScrollableMenu/classes/buttonGroup_class.lua:171: attempt to index a nil value
 
 [Added]
-#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a (sub)menu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -282,7 +282,6 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 Max error #: 2025_61
 
 [FEATURE]
-#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
 
 [KNOWN PROBLEMS]
 #2025_61 Submenu at contextmenu (opend from another submenu) will close the submenu of the context menu automatically if the entry of the opened submenu is not above the LSM dropdown.
@@ -333,6 +332,8 @@ RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
 
 
 [Changed]
+#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(LSM_comboBox, selectedContextMenuItem, openingMenusEntries), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
+--->If it's a fucntion you can also specify doNotFilterEntryTypes = table or function returning a table of LSM entryTypes which should be prefiltering the current list, before the doNotFilter function is executed on them (e.g. { LSM_ENTRY_TYPE_CHECKBOX } to only prefilter checkbox entries of the current list)
 
 [Removed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -279,16 +279,18 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 ---------------------------------------------------------------
 	CHANGELOG Current version: 2.38 - Updated 2025-10-21
 ---------------------------------------------------------------
-Max error #: 2025_42
+Max error #: 2025_43
 
 [KNOWN PROBLEMS]
+#2025_42 is not working for the icons, they do not update at the submenu/menus
 
 [WORKING ON]
-#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
 
 [Fixed]
 
 [Added]
+#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a submenu, if e.g. any other entry was clicked
+#2025_43 Automatically fix wrong formated .icon table format
 
 [Changed]
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -154,8 +154,7 @@ function lib.XML.XMLButtonOnInitialize(control, entryType)
 				if onClickedHandler then
 					onClickedHandler(control, buttonId)
 
-					d("[LSM]lib.XML.XMLButtonOnInitialize -> Checkbox/RadioButton dropdown:SubmenuRefresh")
-					dropdown:SubmenuRefresh(control) --#2025_42
+					dropdown:SubmenuOrCurrentListRefresh(control) --#2025_42
 				end
 
 			elseif buttonId == MOUSE_BUTTON_INDEX_RIGHT then

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -307,7 +307,7 @@ Max error #: 2025_61
 [Added]
 #2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a (sub)menu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
---#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
 --Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
 --> checkFunc(comboBox, control, data)
 --Manual call via API function UpdateCustomScrollableMenuEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -285,7 +285,7 @@ Max error #: 2025_59
 #2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
 
 [KNOWN PROBLEMS]
-#2025_48 Search header is not searching an editBox's text or a slider's balue (only the label's text in front)
+#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
 
 [WORKING ON]
 --#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -277,26 +277,21 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.38 - Updated 2025-11-05
+	CHANGELOG Current version: 2.38 - Updated 2025-11-12
 ---------------------------------------------------------------
-Max error #: 2025_59
+Max error #: 2025_61
 
 [FEATURE[
 #2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(comboBox, entry, currentDropdownEntriesTable), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
 
 [KNOWN PROBLEMS]
-#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
+#2025_61 Submenu at contextmenu (opend from another submenu) will close the submenu of the context menu automatically if the entry of the opened submenu is not above the LSM dropdown.
+--e.g. LSM test -> Normal entry 6 1:1 - ContextMenu with divider tests -> ContextMenu -> Submenu ContextMenu at Submenu Entry6 1:1 - 5 ->
+-->  Submenu Entry 6 -> Move mouse above any opened submenu entry which is not above the LSM dropdowns anymore -> Submenu closes (if mouse is not moved anymore; as long as you move it fast enough above any new submenu it still opens them)
+
 
 [WORKING ON]
---#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
---Manual call via API function lib.UpdateIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
---lib.UpdateIconsPath(comboBox, control, data)
-
---#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
---Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
---> checkFunc(comboBox, control, data)
---Manual call via API function lib.UpdateEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
---lib.UpdateEntryPath(comboBox, control, data, checkFunc)
+#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
 
 
 [Fixed]
@@ -313,7 +308,15 @@ Max error #: 2025_59
 [Added]
 #2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a (sub)menu, if e.g. any other entry was clicked
 #2025_43 Automatically fix wrong formated .icon table format
+--#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
+--> checkFunc(comboBox, control, data)
+--Manual call via API function UpdateCustomScrollableMenuEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
+--UpdateCustomScrollableMenuEntryPath(comboBox, control, data, checkFunc, checkFuncParam1, checkFuncParam2, ...)
 #2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
+--#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
+--Manual call via API function UpdateCustomScrollableMenuEntryIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
+--UpdateCustomScrollableMenuEntryIconsPath(comboBox, control, data)
 #2025_58 API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)
 -->Parameter updateMode can be left empty, then the system will automatically determine if a submenu exists and the item belongs to that, and refresh that,
 --or it will update the mainmenu if it exists.
@@ -323,8 +326,11 @@ Max error #: 2025_59
 --->LSM_UPDATE_MODE_BOTH		Update the submenu and the mainmenu, both
 ---Parameter comboBox is optional
 RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
-#2025_59 Added API function IsCustomScrollableContextMenuShown
+#2025_59 Added API function IsCustomScrollableContextMenuShown()
 --Returns boolean true/false if any LSM context menu is currently showing it's dropdown
+#2025_60 Added API function IsCustomScrollableMenuShown()
+--Returns boolean true/false if any LSM menu is currently showing it's dropdown (including any LSM ContextMenu!)
+
 
 [Changed]
 

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -38,8 +38,8 @@ lib.preventerVars = {
 --Library's XML functions and code
 lib.XML = {}
 
---ContextMenu callbacks which got registered
-lib.contextMenuCallbacksRegistered = {} --#2025_45
+--#2025_45 ContextMenu callbacks which got registered via API function ShowCustomScrollableMenu's parameter specialCallbackData
+lib.contextMenuCallbacksRegistered = {}
 
 --Constants for the library
 lib.constants = {}
@@ -103,7 +103,7 @@ lib.SV = {} --will be init properly at the onAddonLoaded function
 --------------------------------------------------------------------
 -- Other Libraries
 --------------------------------------------------------------------
---LibAddonMenu2, LibDebugLogger
+--LibDebugLogger
 
 
 -----------------------------------------------------------------------
@@ -148,8 +148,9 @@ constants.throttledCallDelay = 		10
 --Handler names
 constants.handlerNames = {}
 constants.handlerNames.dropdownCallLaterHandle = 	MAJOR .. "_Timeout"
-constants.handlerNames.UINarrationName = 			MAJOR .. "_UINarration_"
-constants.handlerNames.UINarrationUpdaterName = 	MAJOR .. "_UINarrationUpdater_"
+local UINarrationName = MAJOR .. "_UINarration"
+constants.handlerNames.UINarrationName = 			UINarrationName .. "_"
+constants.handlerNames.UINarrationUpdaterName = 	UINarrationName .. "Updater_"
 constants.handlerNames.throttledCallDelayName = 	MAJOR .. '_throttledCallDelay'
 
 --ComboBox
@@ -217,15 +218,15 @@ constants.entryTypes.defaults.highlights.subAndContextMenuHighlightAnimationBrea
 
 ------------------------------------------------------------------------------------------------------------------------
 --Entry types - For the scroll list's dataType of the menus
-local LSM_ENTRY_TYPE_NORMAL = 	1
-local LSM_ENTRY_TYPE_DIVIDER = 	2
-local LSM_ENTRY_TYPE_HEADER = 	3
-local LSM_ENTRY_TYPE_SUBMENU = 	4
-local LSM_ENTRY_TYPE_CHECKBOX = 5
-local LSM_ENTRY_TYPE_BUTTON = 6
-local LSM_ENTRY_TYPE_RADIOBUTTON = 7
-local LSM_ENTRY_TYPE_EDITBOX = 8
-local LSM_ENTRY_TYPE_SLIDER = 9
+local LSM_ENTRY_TYPE_NORMAL 		= 1
+local LSM_ENTRY_TYPE_DIVIDER 		= 2
+local LSM_ENTRY_TYPE_HEADER 		= 3
+local LSM_ENTRY_TYPE_SUBMENU 		= 4
+local LSM_ENTRY_TYPE_CHECKBOX		= 5
+local LSM_ENTRY_TYPE_BUTTON 		= 6
+local LSM_ENTRY_TYPE_RADIOBUTTON 	= 7
+local LSM_ENTRY_TYPE_EDITBOX 		= 8
+local LSM_ENTRY_TYPE_SLIDER 		= 9
 
 --Constant for the divider entryType
 lib.DIVIDER = "-"
@@ -253,8 +254,8 @@ for key, value in pairs(scrollListRowTypes) do
 	_G[key] = value
 end
 
---Exclude the OnMouseup handler for these rowTypes (entryTypes) as the callbacks of an editBox/slider should not be executed
---if you click the row, but the editBox text was changed or the slider value was changed (via XML handlers!)
+--Exclude the OnMouseUp handler for these rowTypes (entryTypes) as the callbacks of an editBox/slider should not be executed
+--if you click the row, but the editBox's text/the slider's value was changed (via XML handlers!)
 local onEntryMouseUpExclude = {
 	[LSM_ENTRY_TYPE_EDITBOX] = true,
 	[LSM_ENTRY_TYPE_SLIDER] = true,
@@ -821,6 +822,8 @@ local filteredEntryTypes = {
 	[LSM_ENTRY_TYPE_BUTTON] = 	true,
 	[LSM_ENTRY_TYPE_RADIOBUTTON] = true,
 	--[LSM_ENTRY_TYPE_DIVIDER] = false,
+	[LSM_ENTRY_TYPE_EDITBOX] = true,
+	[LSM_ENTRY_TYPE_SLIDER] = true,
 }
 constants.searchFilter.filteredEntryTypes = filteredEntryTypes
 

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -859,6 +859,7 @@ local filteredEntryTypsChildsToSearch = {
 			dataTable = "editBoxData",
 			dataName = "_EditBoxCtrl",
 			getFunc = "GetText",
+			getFuncReturnType = "string",
 		}
 	},
 	[LSM_ENTRY_TYPE_SLIDER] = {
@@ -866,6 +867,7 @@ local filteredEntryTypsChildsToSearch = {
 			dataTable = "sliderData",
 			dataName = "_SliderCtrl",
 			getFunc = "GetValue",
+			getFuncReturnType = "number",
 		}
 	},
 }

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -851,6 +851,23 @@ local filteredEntryTypes = {
 }
 constants.searchFilter.filteredEntryTypes = filteredEntryTypes
 
+--LSM entryTypes which should not search the LSMentry's name alone, but also another childControl of the LSMentry
+local filteredEntryTypsChildsToSearch = {
+	[LSM_ENTRY_TYPE_EDITBOX] = {
+		[1] = {
+			childName = "EditBox",
+			getFunc = "GetText",
+		}
+	},
+	[LSM_ENTRY_TYPE_SLIDER] = {
+		[1] = {
+			childName = "Slider",
+			getFunc = "GetValue",
+		}
+	},
+}
+constants.searchFilter.filteredEntryTypsChildsToSearch = filteredEntryTypsChildsToSearch
+
 --Table defines if some names of the entries count as "search them or skip them".
 --true: Item's name does not need to be searched -> skip them / false: search the item's name as usual
 local filterNamesExempts = {

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -462,6 +462,8 @@ local comboBoxDefaults = {
 	itemYPad = 						0,
 
 	--LibScrollableMenu internal (e.g. options)
+	automaticRefresh = 				false, --#2025_42
+	automaticSubmenuRefresh =		false, --#2025_42
 	baseEntryHeight = 				ZO_COMBO_BOX_ENTRY_TEMPLATE_HEIGHT,
 	containerMinWidth = 			dropdownDefaults.MIN_WIDTH_WITHOUT_SEARCH_HEADER,
 	disableFadeGradient = 			false,
@@ -472,7 +474,6 @@ local comboBoxDefaults = {
 	submenuArrowColor = 			colors.DEFAULT_ARROW_COLOR,
 	visibleRows = 					dropdownDefaults.DEFAULT_VISIBLE_ROWS,
 	visibleRowsSubmenu = 			dropdownDefaults.DEFAULT_VISIBLE_ROWS,
-	automaticRefresh = 				false, --#2025_42
 }
 constants.comboBox.defaults = comboBoxDefaults
 
@@ -494,6 +495,7 @@ constants.entryTypes.defaults.highlights.defaultHighlightColor = comboBoxDefault
 --The default values for dropdownHelper options -> used for non-passed in options at LSM API functions
 local defaultComboBoxOptions  = {
 	["automaticRefresh"] = 			false, --#2025_42
+	["automaticSubmenuRefresh"] =	false, --#2025_42
 	["enableFilter"] = 				false,
 	["disableFadeGradient"] = 		false,
 	["font"] = 						fonts.DEFAULT_FONT,
@@ -522,6 +524,7 @@ local LSMOptionsKeyToZO_ComboBoxOptionsKey = {
 	-->is defiend below this function will be executed too).
 	-->Missing entries (even if names are the same) will relate in function comboBoxClass:SetOption not respecting the value!
 	["automaticRefresh"] =		"automaticRefresh", --#2025_42
+	["automaticSubmenuRefresh"]= "automaticSubmenuRefresh", --#2025_42
 	["disableFadeGradient"] =	"disableFadeGradient", --Used for the ZO_ScrollList of the dropdown, not the comboBox itsself
 	["disabledColor"] =			"m_disabledColor",
 	["enableFilter"] =			"enableFilter",

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -38,6 +38,9 @@ lib.preventerVars = {
 --Library's XML functions and code
 lib.XML = {}
 
+--ContextMenu callbacks which got registered
+lib.contextMenuCallbacksRegistered = {} --#2025_45
+
 --Constants for the library
 lib.constants = {}
 local constants = lib.constants

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -852,16 +852,19 @@ local filteredEntryTypes = {
 constants.searchFilter.filteredEntryTypes = filteredEntryTypes
 
 --LSM entryTypes which should not search the LSMentry's name alone, but also another childControl of the LSMentry
+--which was added to the data table as e.g. ._EditBoxCtrl reference
 local filteredEntryTypsChildsToSearch = {
 	[LSM_ENTRY_TYPE_EDITBOX] = {
 		[1] = {
-			childName = "EditBox",
+			dataTable = "editBoxData",
+			dataName = "_EditBoxCtrl",
 			getFunc = "GetText",
 		}
 	},
 	[LSM_ENTRY_TYPE_SLIDER] = {
 		[1] = {
-			childName = "Slider",
+			dataTable = "sliderData",
+			dataName = "_SliderCtrl",
 			getFunc = "GetValue",
 		}
 	},

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -472,6 +472,7 @@ local comboBoxDefaults = {
 	submenuArrowColor = 			colors.DEFAULT_ARROW_COLOR,
 	visibleRows = 					dropdownDefaults.DEFAULT_VISIBLE_ROWS,
 	visibleRowsSubmenu = 			dropdownDefaults.DEFAULT_VISIBLE_ROWS,
+	automaticRefresh = 				false, --#2025_42
 }
 constants.comboBox.defaults = comboBoxDefaults
 
@@ -492,6 +493,7 @@ constants.entryTypes.defaults.highlights.defaultHighlightColor = comboBoxDefault
 
 --The default values for dropdownHelper options -> used for non-passed in options at LSM API functions
 local defaultComboBoxOptions  = {
+	["automaticRefresh"] = 			false, --#2025_42
 	["enableFilter"] = 				false,
 	["disableFadeGradient"] = 		false,
 	["font"] = 						fonts.DEFAULT_FONT,
@@ -519,6 +521,7 @@ local LSMOptionsKeyToZO_ComboBoxOptionsKey = {
 	-->e.g. options.visibleRowsDropdown -> Will be saved at comboBox.visibleRows (and if a function in table LSMOptionsToZO_ComboBoxOptionsCallbacks
 	-->is defiend below this function will be executed too).
 	-->Missing entries (even if names are the same) will relate in function comboBoxClass:SetOption not respecting the value!
+	["automaticRefresh"] =		"automaticRefresh", --#2025_42
 	["disableFadeGradient"] =	"disableFadeGradient", --Used for the ZO_ScrollList of the dropdown, not the comboBox itsself
 	["disabledColor"] =			"m_disabledColor",
 	["enableFilter"] =			"enableFilter",

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -337,11 +337,21 @@ local additionalDataKeyToLSMEntryType = {
 constants.entryTypes.additionalDataKeyToLSMEntryType = additionalDataKeyToLSMEntryType
 
 --##2025_44/2025_57 Table with entry's data key which could raise an automatic update of the entry, and all parentMenu
---entries. The index of this table defines the priority -> The lower the index, the higher the priority
-constants.entryTypes.dataAllowedAutomaticUpdateRaise ={
-	[1] = "updateEntryPath",
-	[2] = "updateIconPath",
+--entries.
+local updateEntryPathsData = {
+	updateEntryPath = "updateEntryPath",
+	updateEntryPathCheckFunc = "updateEntryPathCheckFunc",
+	updateIconPath = "updateIconPath"
 }
+constants.entryTypes.updateEntryPathsData = updateEntryPathsData
+
+--The index of this table defines the priority -> The lower the index, the higher the priority (the higher the priority the
+--earlier this data's callback function is called)
+local dataAllowedAutomaticUpdateRaise = {
+	[1] = updateEntryPaths.updateEntryPath,
+	[2] = updateEntryPaths.updateIconPath,
+}
+constants.entryTypes.dataAllowedAutomaticUpdateRaise = dataAllowedAutomaticUpdateRaise
 
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -52,6 +52,7 @@ local constants = lib.constants
 lib.Debug = {}
 lib.Debug.doDebug = false
 lib.Debug.doVerboseDebug = false
+lib.Debug.controlNameCache = {}
 
 local debugPrefix = "[" .. MAJOR .. "]"
 lib.Debug.prefix = debugPrefix
@@ -227,6 +228,12 @@ local LSM_ENTRY_TYPE_BUTTON 		= 6
 local LSM_ENTRY_TYPE_RADIOBUTTON 	= 7
 local LSM_ENTRY_TYPE_EDITBOX 		= 8
 local LSM_ENTRY_TYPE_SLIDER 		= 9
+
+--Updater modes for the menus (See API function RefreshCustomScrollableMenu)
+LSM_UPDATE_MODE_MAINMENU = 1
+LSM_UPDATE_MODE_SUBMENU = 2
+LSM_UPDATE_MODE_BOTH = 99
+
 
 --Constant for the divider entryType
 lib.DIVIDER = "-"

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -329,6 +329,13 @@ local additionalDataKeyToLSMEntryType = {
 }
 constants.entryTypes.additionalDataKeyToLSMEntryType = additionalDataKeyToLSMEntryType
 
+--##2025_44/2025_57 Table with entry's data key which could raise an automatic update of the entry, and all parentMenu
+--entries. The index of this table defines the priority -> The lower the index, the higher the priority
+constants.entryTypes.dataAllowedAutomaticUpdateRaise ={
+	[1] = "updateEntryPath",
+	[2] = "updateIconPath",
+}
+
 
 ------------------------------------------------------------------------------------------------------------------------
 --Row highlights (on mouse enter)

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -348,8 +348,8 @@ constants.entryTypes.updateEntryPathsData = updateEntryPathsData
 --The index of this table defines the priority -> The lower the index, the higher the priority (the higher the priority the
 --earlier this data's callback function is called)
 local dataAllowedAutomaticUpdateRaise = {
-	[1] = updateEntryPaths.updateEntryPath,
-	[2] = updateEntryPaths.updateIconPath,
+	[1] = updateEntryPathsData.updateEntryPath,
+	[2] = updateEntryPathsData.updateIconPath,
 }
 constants.entryTypes.dataAllowedAutomaticUpdateRaise = dataAllowedAutomaticUpdateRaise
 

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -6,7 +6,7 @@ if LibScrollableMenu ~= nil then return end -- the same or newer version of this
 local lib = ZO_CallbackObject:New()
 lib.name = "LibScrollableMenu"
 lib.author = "Baertram, IsJustaGhost, tomstock, Kyoma"
-lib.version = "2.37"
+lib.version = "2.38"
 if not lib then return end
 --------------------------------------------------------------------
 

--- a/LibScrollableMenu/debug/LSM_debug.lua
+++ b/LibScrollableMenu/debug/LSM_debug.lua
@@ -233,6 +233,9 @@ local debugLogMessagePatterns = {
 	[190] = "comboBox_base:SetupEntrySlider - control: %s, list: %s",
 	[191] = "AddCustomScrollableMenuSlider-text: %s, sliderData: %s",
 	[192] = "dropdownClass:SubmenuRefresh - control:  %s",
+	[193] = "onEntryCallbackUpdateIcons - control:  %s",
+	[194] = "updateSubmenuIcons",
+	[195] = "FireCallbacks: IconUpdated - control:  %s",
 }
 
 

--- a/LibScrollableMenu/debug/LSM_debug.lua
+++ b/LibScrollableMenu/debug/LSM_debug.lua
@@ -232,6 +232,7 @@ local debugLogMessagePatterns = {
 	[189] = "AddCustomScrollableMenuRadioButton-text: %s, checked: %s, buttonGroup: %s",
 	[190] = "comboBox_base:SetupEntrySlider - control: %s, list: %s",
 	[191] = "AddCustomScrollableMenuSlider-text: %s, sliderData: %s",
+	[192] = "dropdownClass:SubmenuRefresh - control:  %s",
 }
 
 

--- a/LibScrollableMenu/debug/LSM_debug.lua
+++ b/LibScrollableMenu/debug/LSM_debug.lua
@@ -233,9 +233,11 @@ local debugLogMessagePatterns = {
 	[190] = "comboBox_base:SetupEntrySlider - control: %s, list: %s",
 	[191] = "AddCustomScrollableMenuSlider-text: %s, sliderData: %s",
 	[192] = "dropdownClass:SubmenuRefresh - control:  %s",
-	[193] = "onEntryCallbackUpdateIcons - control:  %s",
-	[194] = "updateSubmenuIcons",
+	[193] = "onEntryCallbackUpdateIconsPath - control:  %s",
+	[194] = "updateParentEntryRecursively",
 	[195] = "FireCallbacks: IconUpdated - control:  %s",
+	[196] = "onEntryCallbackUpdateEntryPath - control:  %s",
+	[197] = "checkIfEntryRaisesAutomaticUpdate - control:  %s, checkFuncForRefresh: %s",
 }
 
 

--- a/LibScrollableMenu/lang/de.lua
+++ b/LibScrollableMenu/lang/de.lua
@@ -12,7 +12,7 @@ GERMAN
 ]]--
 
 local stringsDE = {
-	SI_LSM_SEARCH_FILTER_TOOLTIP = "Gib einen Suchbegriff ein, um die Einträge der Menüs und (mehrstufigen) Untermenüs zu filtern.\nSchreibe \'/\' davor, um nicht passende Untermenüs dennoch anzuzeigen.",
+	SI_LSM_SEARCH_FILTER_TOOLTIP = "Gib einen Suchbegriff ein, um die Einträge der Menüs und (mehrstufigen) Untermenüs zu filtern.\nSchreibe \'/\' davor, um nicht passende Untermenü-Einträge dennoch anzuzeigen.",
 
     SI_LSM_CNTXT_CHECK_ALL = "Alle wählen",
     SI_LSM_CNTXT_CHECK_NONE = "Keine wählen",

--- a/LibScrollableMenu/lang/en.lua
+++ b/LibScrollableMenu/lang/en.lua
@@ -1,6 +1,6 @@
 -- Messages settings
 local strings = {
-	SI_LSM_SEARCH_FILTER_TOOLTIP = "Enter a search term to filter the menus and (nested) submenu entries.\nPrefix search with \'/\' shows non matching submenus too",
+	SI_LSM_SEARCH_FILTER_TOOLTIP = "Enter a search term to filter the menus and (nested) submenu entries.\nPrefix search with \'/\' shows non matching submenu-entries too",
 
     SI_LSM_CNTXT_CHECK_ALL = "Check all",
     SI_LSM_CNTXT_CHECK_NONE = "Check none",

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -109,6 +109,7 @@ local function test()
 
 			selectedSoundDisabled = false,
 			automaticRefresh = true,
+			automaticSubmenuRefresh = false,
 
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -278,7 +278,7 @@ local function test()
 					d("I changed the editbox 1 submenu text, to: " .. tostring(text))
 				end,
 				enabled 		= true,
-				doNotFilter		= true,
+				doNotFilter = true,
 				editBoxData = {
 					hideLabel = true,
 					labelWidth = "20%",
@@ -738,7 +738,21 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 				end,
 				enabled			= true,
 				icon			= { "/esoui/art/inventory/inventory_trait_ornate_icon.dds", "EsoUI/Art/Inventory/inventory_trait_intricate_icon.dds", "EsoUI/Art/Inventory/inventory_trait_not_researched_icon.dds" },
-				doNotFilter		= false,
+				doNotFilter		= function(LSM_comboBox, selectedContextMenuItem, openingMenusEntries)
+					d("[LSM Test]EditBox1 - doNotFilter check")
+					if not ZO_IsTableEmpty(openingMenusEntries) then
+						for _, entryData in ipairs(openingMenusEntries) do
+							if entryData and entryData.name then
+								if entryData.name == "EditBox1" then
+									d(">Found current dropdown's EditBox1! DoNotFilter it")
+									return true
+								end
+							end
+						end
+					end
+					return false
+				end,
+				--doNotFilterEntryTypes = function() return { LSM_ENTRY_TYPE_CHECKBOX } end,
 				editBoxData = {
 					hideLabel = 			false,
 					labelWidth = 			"10%",

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -2,6 +2,8 @@ local lib = LibScrollableMenu
 local MAJOR = lib.name
 
 local debugPrefix = lib.Debug.prefix
+local libUtil = lib.Util
+local getValueOrCallback = libUtil.getValueOrCallback
 
 ------------------------------------------------------------------------------------------------------------------------
 -- For testing - Combobox with all kind of entry types (test offsets, etc.)
@@ -52,19 +54,19 @@ local function test()
 				return "Submenu hide"
 			end,
 			["OnEntryMouseEnter"] =		function(m_dropdownObject, entryControl, data, hasSubmenu)
-				local entryName = lib.GetValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
+				local entryName = getValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
 				return "Entry Mouse entered: " ..entryName .. ", hasSubmenu: " ..tostring(hasSubmenu)
 			end,
 			["OnEntryMouseExit"] =		function(m_dropdownObject, entryControl, data, hasSubmenu)
-				local entryName = lib.GetValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
+				local entryName = getValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
 				return "Entry Mouse exit: " ..entryName .. ", hasSubmenu: " ..tostring(hasSubmenu)
 			end,
 			["OnEntrySelected"] =		function(m_dropdownObject, entryControl, data, hasSubmenu)
-				local entryName = lib.GetValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
+				local entryName = getValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
 				return "Entry selected: " ..entryName .. ", hasSubmenu: " ..tostring(hasSubmenu)
 			end,
 			["OnCheckboxUpdated"] =		function(m_dropdownObject, checkboxControl, data)
-				local entryName = lib.GetValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
+				local entryName = getValueOrCallback(data.label ~= nil and data.label or data.name, data) or "n/a"
 				local isChecked = ZO_CheckButton_IsChecked(checkboxControl)
 				return "Checkbox updated: " ..entryName .. ", checked: " ..tostring(isChecked)
 			end,
@@ -80,16 +82,25 @@ local function test()
 
 
 		local function customFilterFunc(p_item, p_filterString)
+			d("[LSM Test]customFilterFunc")
 			local name = p_item.label or p_item.name
 			if p_item.customFilterFuncData ~= nil then
 				if p_item.customFilterFuncData.findMe ~= nil then
-			d(">customFilterFunc - findMe: " ..tostring(p_item.customFilterFuncData.findMe))
+			d(">findMe: " ..tostring(p_item.customFilterFuncData.findMe))
 					return zo_strlower(p_item.customFilterFuncData.findMe):find(p_filterString) ~= nil
 				end
 			end
 			return false
 		end
 
+		local function onEntryCallback_updateEntryPathCheckFunc(comboBox, control, data)
+			if data == nil then
+				d("<<ERROR: data is nil!")
+			end
+			local retVar = (data ~= nil and data.name == "Normal entry 6 1:2" and true ) or false
+			d("[LSM Test]onEntryCallback_updateEntryPathCheckFunc - name: " .. tostring(((data ~= nil and data.label) or data.name) or "n/a") .. ", retVar: " .. tostring(retVar))
+			return retVar
+		end
 
 		--==============================================================================================================
 		-- Options for the main combobox menu
@@ -985,9 +996,13 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 					end
 				end,
 				--	callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
-				callback        =   function(self)
-					d("Entry with label 1!")
+				callback        =   function(comboBox, itemName, item, selectionChanged, oldItem)
+					d("Clicked: " .. tostring(getValueOrCallback(item.label)))
 				end,
+				updateEntryPathCheckFunc = onEntryCallback_updateEntryPathCheckFunc,
+				updateEntryPath = true,
+
+
 				--entries         = submenuEntries,
 				--tooltip         =
 				--type = lib.LSM_ENTRY_TYPE_CHECKBOX
@@ -1235,6 +1250,8 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 						end,
 						--tooltip         = "Submenu Entry Test 1",
 						--icon 			= nil,
+						updateEntryPathCheckFunc = onEntryCallback_updateEntryPathCheckFunc,
+						updateEntryPath = true,
 					},
 				},
 				--	tooltip         = function() return "Submenu entry 6"  end

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -1307,6 +1307,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 		-- This example callback is checking if the data matches a checkbox entry from this addon.
 		lib:RegisterCallback('CheckboxUpdated', function(checked, data, checkbox)
 			-- Callback is fired on checkbox checked state change
+--d("[LSM]test - Checkbox callback")
 			if entryMap[data] ~= nil then
 				-- Belongs to this addon
 			end

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -108,6 +108,7 @@ local function test()
 			OnSelectionBlockedCallback = function() d(debugPrefix.."ERROR - Selection of entry was blocked!") end,
 
 			selectedSoundDisabled = false,
+			automaticRefresh = true,
 
 			visibleRowsDropdown = 10,
 			visibleRowsSubmenu = 10,

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -739,12 +739,11 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 				enabled			= true,
 				icon			= { "/esoui/art/inventory/inventory_trait_ornate_icon.dds", "EsoUI/Art/Inventory/inventory_trait_intricate_icon.dds", "EsoUI/Art/Inventory/inventory_trait_not_researched_icon.dds" },
 				doNotFilter		= function(LSM_comboBox, selectedContextMenuItem, openingMenusEntries)
-					d("[LSM Test]EditBox1 - doNotFilter check")
 					if not ZO_IsTableEmpty(openingMenusEntries) then
 						for _, entryData in ipairs(openingMenusEntries) do
 							if entryData and entryData.name then
 								if entryData.name == "EditBox1" then
-									d(">Found current dropdown's EditBox1! DoNotFilter it")
+									d("[LSM Test]Found current dropdown's EditBox1! DoNotFilter it")
 									return true
 								end
 							end

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -677,7 +677,8 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 				name            = "Button1",
 				tooltip         = "Button button button...",
 				callback 		= function(comboBox, itemName, item, selectionChanged, oldItem)
-					d("I clicked a button with the name: " .. tostring(itemName))
+					sliderValue = 500000
+					d("I clicked a button with the name: " .. tostring(itemName) .. " and changed the slider below to " .. tostring(sliderValue))
 				end,
 				doNotFilter		= true,
 			},


### PR DESCRIPTION
LSM v2.38 - 2025-11-14
[Fixed]
#2025_46 Clicking a disabled entry at a contextmenu submenu will close the submenu as the control is not mouseEnabled and the scrollList control below is clicked. Detection of the scrollList's owner
#2025_47 Clicking a scrollbar at a contextmenu (submenu) will close the contextmenu (submenu)
#2025_48 Search header is not searching an editBox's text or a slider's value (only the label's text in front)
#2025_49 Editbox clicked at context menu's submenu will close the contextmenu
#2025_50 Slider clicked at context menu's submenu will close the contextmenu
#2025_51 MultiIcon clicked at context menu's submenu will close the contextmenu
#2025_52 Checkbox [ ] part clicked in a submenu closes the submenu
#2025_53 Checkbox label or [ ] part clicked in a contextmenu's submenu closes the submenu
#2025_54 Radiobutton label or [ ] part clicked in a contextmenu's submenu closes the submenu
#2025_55 Radiobutton [ ] part clicked in a contextmenu's submenu raises a lua error user:/AddOns/LibScrollableMenu/classes/buttonGroup_class.lua:171: attempt to index a nil value

[Added]
#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a (sub)menu, if e.g. any other entry was clicked
#2025_43 Automatically fix wrong formated .icon table format
#2025_44 Recursively check if any entry on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
--Optional checkFunc must return a boolean true [default return value] (refresh now) or false (no refresh needed), and uses the signature:
--> checkFunc(comboBox, control, data)
--Manual call via API function UpdateCustomScrollableMenuEntryPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateEntryPath == true
--UpdateCustomScrollableMenuEntryPath(comboBox, control, data, checkFunc, checkFuncParam1, checkFuncParam2, ...)
#2025_45 Register special contextMenu OnShow and/or OnHide callback for registered contextMenus (done at ShowCustomScrollableMenu, last parameter specialCallbackData.addonName and specialCallbackData.onHideCallback e.g.)
--#2025_57 Recursively check if any icon on the current submenu's path, up to the main menu (via the parentMenus), needs an update.
--Manual call via API function UpdateCustomScrollableMenuEntryIconsPath (e.g. from any callback of an entry) or automatic call if submenuEntry.updateIconPath == true
--UpdateCustomScrollableMenuEntryIconsPath(comboBox, control, data)
#2025_58 API to refresh a dropdown's submenu or mainmenu or an entry control visually (e.g. if you click an entry, called from the callback function)
-->Parameter updateMode can be left empty, then the system will automatically determine if a submenu exists and the item belongs to that, and refresh that,
--or it will update the mainmenu if it exists.
--Or you specify one of the following updateModes:
--->LSM_UPDATE_MODE_MAINMENU Only update the mainmenu visually
--->LSM_UPDATE_MODE_SUBMENU Only update the submenu visually
--->LSM_UPDATE_MODE_BOTH Update the submenu and the mainmenu, both
---Parameter comboBox is optional
RefreshCustomScrollableMenu(mocCtrl, updateMode, comboBox)
#2025_59 Added API function IsCustomScrollableContextMenuShown()
--Returns boolean true/false if any LSM context menu is currently showing it's dropdown
#2025_60 Added API function IsCustomScrollableMenuShown()
--Returns boolean true/false if any LSM menu is currently showing it's dropdown (including any LSM ContextMenu!)

[Changed]
#2025_56 Change entry's data.doNotFilter: If it's a function it's signature now is doNotFilterFunc(LSM_comboBox, selectedContextMenuItem, openingMenusEntries), so one can e.g. make a button entryType only filter if there is no other entry inside the table currentDropdownEntriesTable
--->If it's a fucntion you can also specify doNotFilterEntryTypes = table or function returning a table of LSM entryTypes which should be prefiltering the current list, before the doNotFilter function is executed on them (e.g. { LSM_ENTRY_TYPE_CHECKBOX } to only prefilter checkbox entries of the current list)