### PR TITLE
LSM v2.40

### DIFF
--- a/ESOUI_description.txt
+++ b/ESOUI_description.txt
@@ -95,11 +95,19 @@ API syntax:
 --		number titleTextAlignment:optional		Number or function returning a number: The title's vertical alignment, e.g. TEXT_ALIGN_CENTER
 --		userdata customHeaderControl:optional	Userdata or function returning Userdata: A custom control thta should be shown above the dropdown entries
 --		boolean headerCollapsible			 	Boolean or function returning boolean if the header control should show a collapse/expand button
+--		boolean headerCollapsed			 		Boolean or function returning boolean if the header control should always be collapsed as the dropdown is opened. If this is false (default) the last state will be saved in LSM SavedVariables (per dropdown box name)
+--		string headerToggleTooltip				String or function returning a string: Tooltip text for the collapse/expand buttons. Function signature function(state). Default: returns "Collapse"/"Expand" strings from vanilla ESOUI, depending on the current state
+--		table headerCollapsedIcon				table or function returning a table of signature { iconTexture = "path/to/textureName.dds", iconTint=ZO_ColorDef, width=number, height=number, align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Icon shown as the header is collapsed (e.g. a magnifying glass to show you can expand it to get a search). Default value is nil. Height is capped at 32!
+--		table headerCollapsedTitle				table or function returning a table of signature { text = "Click to search", color=ZO_ColorDef, font="FontNameHere", align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Title text shown as the header is collapsed (e.g. a text to show you can expand the section and see the search). Default value is nil.
 -->  === Dropdown text search & filter =================================================================================
 --		boolean enableFilter:optional			Boolean or function returning boolean which controls if the text search/filter editbox at the dropdown header is shown
 --		function customFilterFunc				A function returning a boolean true: show item / false: hide item. Signature of function: customFilterFunc(item, filterString)
 --->  === Dropdown callback functions
 -- 		function preshowDropdownFn:optional 	function function(ctrl) codeHere end: to run before the dropdown shows
+--		boolean automaticRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the normal scrolllist should happen, if you click/change any entry's value. This would be needed
+--												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
+--		boolean automaticSubmenuRefresh:optional		Boolean or function returning boolean which controls if the automatic refresh of the submenu's scrolllist should happen, if you click/change any entry's value. This would be needed
+--												e.g. if you want the entry B to react on entry A's value (e.g. checkboxes -> enabled state). Default value is false
 --->  === Dropdown's Custom XML virtual row/entry templates ============================================================
 --		boolean useDefaultHighlightForSubmenuWithCallback	Boolean or function returning a boolean if always the default ZO_ComboBox highlight XML template should be used for an entry having a submenu AND a callback function. If false the highlight 'LibScrollableMenu_Highlight_Green' will be used
 --		table XMLRowTemplates:optional			Table or function returning a table with key = row type of lib.scrollListRowTypes and the value = subtable having

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -131,6 +131,9 @@ end
 --		userdata customHeaderControl:optional	Userdata or function returning Userdata: A custom control thta should be shown above the dropdown entries
 --		boolean headerCollapsible			 	Boolean or function returning boolean if the header control should show a collapse/expand button
 --		boolean headerCollapsed			 		Boolean or function returning boolean if the header control should always be collapsed as the dropdown is opened. If this is false (default) the last state will be saved in LSM SavedVariables (per dropdown box name)
+--		string headerToggleTooltip				String or function returning a string: Tooltip text for the collapse/expand buttons. Function signature function(state). Default: returns "Collapse"/"Expand" strings from vanilla ESOUI, depending on the current state
+--		table headerCollapsedIcon				table or function returning a table of signature { iconTexture = "path/to/textureName.dds", iconTint=ZO_ColorDef, width=number, height=number, align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Icon shown as the header is collapsed (e.g. a magnifying glass to show you can expand it to get a search). Default value is nil. Height is capped at 32!
+--		table headerCollapsedTitle				table or function returning a table of signature { text = "Click to search", color=ZO_ColorDef, font="FontNameHere", align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Title text shown as the header is collapsed (e.g. a text to show you can expand the section and see the search). Default value is nil.
 -->  === Dropdown text search & filter =================================================================================
 --		boolean enableFilter:optional			Boolean or function returning boolean which controls if the text search/filter editbox at the dropdown header is shown
 --		function customFilterFunc				A function returning a boolean true: show item / false: hide item. Signature of function: customFilterFunc(item, filterString)

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.39
-## AddOnVersion: 020309
+## Version: 2.40
+## AddOnVersion: 020400
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101048 101049

--- a/LibScrollableMenu/XML/LibScrollableMenu.xml
+++ b/LibScrollableMenu/XML/LibScrollableMenu.xml
@@ -364,11 +364,11 @@
 
 			<Controls>
 				<Label name="$(parent)Label" verticalAlignment="CENTER" wrapMode="ELLIPSIS" maxLineCount="1">
-					<DimensionConstraints x="5" maxX="90%" />
+					<DimensionConstraints minX="5" maxX="90%" />
 					<Anchor point="TOPLEFT" relativeTo="$(parent)IconContainer" relativePoint="TOPRIGHT" offsetX="1" />
 				</Label>
 				<Control name="$(parent)SliderContainer">
-					<DimensionConstraints x="100%" maxX="100%" />
+					<DimensionConstraints minx="5" maxX="100%" />
 					<Anchor point="TOPLEFT" relativeTo="$(parent)Label" relativePoint="TOPRIGHT" offsetX="4"/>
 					<Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" offsetX="-2"/>
 					<Controls>
@@ -460,6 +460,8 @@
 							[headerControls.CUSTOM_CONTROL] 	= self:GetNamedChild("CustomControl"),
 							[headerControls.TOGGLE_BUTTON] 		= self:GetNamedChild("ToggleHeader"),
 							[headerControls.TOGGLE_BUTTON_CLICK_EXTENSION] 		= self:GetNamedChild("ToggleHeaderClickExtension"),
+							[headerControls.TOGGLE_ICON] 		= self:GetNamedChild("ToggleHeaderIcon"),
+							[headerControls.TOGGLE_TITLE] 		= self:GetNamedChild("ToggleHeaderTitle"),
 						}
 						self:GetParent().header = self
 
@@ -500,9 +502,9 @@
 						</Control>
 
 						<!--Label name="$(parent)Title" inherits="ZO_GamepadScreenHeaderTitleTextTemplate" excludeFromResizeToFitExtents="true" -->
-						<Label name="$(parent)Title" hidden="true"/>
+						<Label name="$(parent)Title" hidden="true" level="3" />
 						<!--Label name="$(parent)SubTitle" inherits="ZO_GamepadHeaderLabelTextTemplate" horizontalAlignment="CENTER" excludeFromResizeToFitExtents="true" color="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_SELECTED" hidden="true"-->
-						<Label name="$(parent)SubTitle" horizontalAlignment="CENTER" color="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_SELECTED" hidden="true"/>
+						<Label name="$(parent)SubTitle" level="3" horizontalAlignment="CENTER" color="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_SELECTED" hidden="true"/>
 
 						<Control name="$(parent)DividerSimple" hidden="true">
 							<Dimensions y="16" />
@@ -577,83 +579,6 @@
 									</Controls>
 								</Backdrop>
 
-								<!--
-								<Button name="$(parent)Settings" inherits="ZO_ButtonBehaviorClickSound">
-									<Dimensions x="32" y="32" />
-									<Anchor point="RIGHT" relativeTo="$(parent)" relativePoint="RIGHT" offsetX="-ZO_SCROLLABLE_COMBO_BOX_LIST_PADDING_Y" offsetY="0" />
-
-									<Textures normal="esoui/art/chatwindow/chat_options_up.dds"
-									  pressed="esoui/art/chatwindow/chat_options_down.dds"
-									  mouseOver="esoui/art/chatwindow/chat_options_over.dds"/>
-
-									<OnMouseEnter>
-										ZO_Tooltips_ShowTextTooltip(self, BOTTOM, GetString(SI_GAME_MENU_SETTINGS))
-										InformationTooltipTopLevel:BringWindowToTop()
-									</OnMouseEnter>
-
-									<OnMouseExit>
-										ZO_Tooltips_HideTextTooltip()
-									</OnMouseExit>
-
-									<OnClicked>
-										ZO_Tooltips_HideTextTooltip()
-										local owningWindow = self:GetOwningWindow()
-										if owningWindow.object then
-											owningWindow.object:ShowFilterSettings(owningWindow, self)
-										end
-									</OnClicked>
-								</Button>
-								-->
-
-								<!--Button name="$(parent)Include" inherits="ZO_DefaultTextButton" text="S">
-									<Dimensions x="32" y="32" />
-									<Anchor point="LEFT" relativeTo="$(parent)Filter" relativePoint="RIGHT" offsetX="-8" offsetY="0" />
-
-									<OnInitialized>
-										self.uncheckedText = 'S'
-										self.checkedText = 'l'
-
-										self.toggleFunction = function(button, checked)
-											local owningWindow = self:GetOwningWindow()
-											if owningWindow.object then
-												owningWindow.object:SetFilterIgnore(checked)
-											end
-										end
-
-									</OnInitialized>
-
-									<OnClicked>
-										ZO_CheckButton_OnClicked(self, button)
-
-										- Show updated tooltip on click
-										ClearTooltip(InformationTooltip)
-										InitializeTooltip(InformationTooltip, self, BOTTOM, 0, 0)
-										SetTooltipText(InformationTooltip, GetString('LIBSCROLLABLEMENU_SI_MATCHTOOLTIP', self:GetState()))
-										InformationTooltipTopLevel:BringWindowToTop()
-
-										- Can't remember what one is 0 and 1
-										- LIBSCROLLABLEMENU_SI_MATCHTOOLTIP0 = 'Strict'
-										- LIBSCROLLABLEMENU_SI_MATCHTOOLTIP1 = 'Loose'
-									</OnClicked>
-
-									<OnEffectivelyShown>
-										local bState = self:GetState()
-										local checked = bState == BSTATE_PRESSED
-										- get saved button state
-										ZO_CheckButton_SetCheckState(self, checked)
-									</OnEffectivelyShown>
-
-									<OnMouseEnter>
-										InitializeTooltip(InformationTooltip, self, BOTTOM, 0, 0)
-										SetTooltipText(InformationTooltip, GetString('LIBSCROLLABLEMENU_SI_MATCHTOOLTIP', self:GetState()))
-										InformationTooltipTopLevel:BringWindowToTop()
-									</OnMouseEnter>
-
-									<OnMouseExit>
-										ClearTooltip(InformationTooltip)
-									</OnMouseExit>
-								</Button-->
-
 							</Controls>
 						</Control>
 
@@ -665,7 +590,7 @@
 						</Control>
 
 						<Button name="$(parent)ToggleHeader" inherits="ZO_ButtonBehaviorClickSound" hidden="true">
-							<DimensionConstraints minY="24" maxY="24" minX="24" />
+							<DimensionConstraints minY="24" maxY="100%" minX="24" />
 
 							<OnInitialized>
 								local owningWindow = self:GetOwningWindow()
@@ -679,10 +604,21 @@
 								
 								self.GetTooltipText = function()
 									local currentState = self:GetState()
-									if currentState == BSTATE_PRESSED then
-										return GetString(SI_ITEM_SETS_BOOK_HEADER_EXPAND) -- "Expand"
-									elseif currentState == BSTATE_NORMAL then
-										return GetString(SI_ITEM_SETS_BOOK_HEADER_COLLAPSE) -- "Collapse"
+									-- -v- #2025_64
+									local owningWindow = self:GetOwningWindow()
+									if owningWindow and owningWindow.object and owningWindow.object.m_comboBox then
+										local options = owningWindow.object.m_comboBox:GetOptions()
+										local customToogleHeaderTooltipText = (options ~= nil and LibScrollableMenu.Util.getValueOrCallback(options.headerToggleTooltip, currentState)) or nil
+										if type(customToogleHeaderTooltipText) == "string" then
+											return customToogleHeaderTooltipText
+										end
+									else
+									-- -^- #2025_64
+										if currentState == BSTATE_PRESSED then
+											return GetString(SI_ITEM_SETS_BOOK_HEADER_EXPAND) -- "Expand"
+										elseif currentState == BSTATE_NORMAL then
+											return GetString(SI_ITEM_SETS_BOOK_HEADER_COLLAPSE) -- "Collapse"
+										end
 									end
 									return ''
 								end
@@ -711,8 +647,18 @@
 							</OnClicked>
 						</Button>
 
-						<Button name="$(parent)ToggleHeaderClickExtension" inherits="ZO_ButtonBehaviorClickSound" hidden="true">
-							<DimensionConstraints minY="0" maxY="24" minX="0" />
+						<Texture name="$(parent)ToggleHeaderIcon" inherits="ZO_MultiIcon" mouseEnabled="false" hidden="true" level="2">
+							<DimensionConstraints minX="0" maxX="95%" minY="0" maxY="32" />
+							<Anchor point="CENTER"/>
+						</Texture>
+
+						<Label name="$(parent)ToggleHeaderTitle" hidden="true" level="3">
+							<DimensionConstraints minX="0" maxX="95%" minY="0" maxY="32" />
+							<Anchor point="CENTER"/>
+						</Label>
+
+						<Button name="$(parent)ToggleHeaderClickExtension" inherits="ZO_ButtonBehaviorClickSound" hidden="true" level="5">
+							<DimensionConstraints minX="0" maxX="100%" minY="0" maxY="100%" />
 
 							<OnInitialized>
 								local owningWindow = self:GetOwningWindow()
@@ -731,11 +677,8 @@
 							</OnMouseExit>
 
 							<OnClicked>
-								--ZO_Tooltips_HideTextTooltip()
-
 								local owningWindow = self:GetOwningWindow()
 								local toggleButton = owningWindow.toggleButton
-								--ZO_CheckButton_OnClicked(toggleButton)
 								LibScrollableMenu.XML.OnXMLControlEventHandler("ToggleHeader", self, toggleButton)
 							</OnClicked>
 						</Button>

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,7 +1,15 @@
+-v- ---------------LSM v2.40 - 2025-12-14--------------------------------------------------------------------------- -v-
+[Added]
+#2025_63 Add options.headerCollapsedIcon and options.headerCollapsedTitle
+--		table headerCollapsedIcon				table or function returning a table of signature { iconTexture = "path/to/textureName.dds", iconTint=ZO_ColorDef, width=number, height=number, align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Icon shown as the header is collapsed (e.g. a magnifying glass to show you can expand it to get a search). Default value is nil. Height is capped at 32!
+--		table headerCollapsedTitle				table or function returning a table of signature { text = "Click to search", color=ZO_ColorDef, font="FontNameHere", align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Title text shown as the header is collapsed (e.g. a text to show you can expand the section and see the search). Default value is nil.
+#2025_64 options.headerToggleTooltip
+--		string headerToggleTooltip				String or function returning a string: Tooltip text for the collapse/expand buttons. Function signature function(state). Default: returns "Collapse"/"Expand" strings from vanilla ESOUI, depending on the current state
+
+
 -v- ---------------LSM v2.39 - 2025-12-09--------------------------------------------------------------------------- -v-
 [Fixed]
 #2025_62 headerCollapsed is not working and making the search header always collapsed on open (it still uses last used state as it seems)
-
 
 -v- ---------------LSM v2.38 - 2025-11-14--------------------------------------------------------------------------- -v-
 [WORKING ON]

--- a/LibScrollableMenu/code/LSM_Util.lua
+++ b/LibScrollableMenu/code/LSM_Util.lua
@@ -21,11 +21,15 @@ local AM = GetAnimationManager() --ANIMATION_MANAGER
 local EM = GetEventManager() --EVENT_MANAGER
 local tos = tostring
 local sfor = string.format
+local strsub = string.sub
+local strlow = string.lower
 
 local functionType = "function"
 local userdataType = "userdata"
 local stringType = "string"
 local tableType = "table"
+
+local ddsExtensionStr = ".dds"
 
 
 -----------------------------------------------------------------------
@@ -75,6 +79,23 @@ local checkIfSubmenuEntriesAreCurrentlySelectedForMultiSelect
 
 --local levelChecked = 0
 local alreadyCheckedSubmenuOpeningItems = {}
+
+--------------------------------------------------------------------
+-- Strings
+--------------------------------------------------------------------
+function libUtil.endsWith(haystack, needle) --#2025_63
+	local suffix = strlow(strsub(haystack, -(#needle)))
+	return suffix == strlow(needle)
+end
+local endsWith = libUtil.endsWith
+
+
+--Check if the an iconPath is a valid string ending on .dds
+function libUtil.checkIfValidTexturePath(texturePath) --#2025_63
+	if type(texturePath) ~= stringType then return false end
+	local endsOnDDS = endsWith(texturePath, ddsExtensionStr)
+	return endsOnDDS
+end
 
 --------------------------------------------------------------------
 -- Controls

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -278,20 +278,21 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.38 - Updated 2025-11-14
+	CHANGELOG Current version: 2.40 - Updated 2025-12-14
 ---------------------------------------------------------------
-Max error #: 2025_62
+Max error #: 2025_64
 
 [FEATURE]
 
 [KNOWN PROBLEMS]
 
 [WORKING ON]
+#2025_64 options.headerToggleTooltip
 
 [Fixed]
-#2025_62 headerCollapsed is not working and making the search header always collapsed on open (it still uses last used state as it seems)
 
 [Added]
+#2025_63 Add options.headerCollapsedIcon and options.headerCollapsedTitle
 
 [Changed]
 

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -6,7 +6,7 @@ if LibScrollableMenu ~= nil then return end -- the same or newer version of this
 local lib = ZO_CallbackObject:New()
 lib.name = "LibScrollableMenu"
 lib.author = "Baertram, IsJustaGhost, tomstock, Kyoma"
-lib.version = "2.39"
+lib.version = "2.40"
 if not lib then return end
 --------------------------------------------------------------------
 
@@ -187,6 +187,7 @@ constants.fonts = {}
 constants.fonts.DEFAULT_FONT = 					"ZoFontGame"
 constants.fonts.HeaderFontTitle = 				"ZoFontHeader3"
 constants.fonts.HeaderFontSubtitle = 			"ZoFontHeader2"
+constants.fonts.HeaderCollapsedTitle =			"ZoFontGamepad18"
 local fonts = constants.fonts
 
 --Colors
@@ -561,6 +562,7 @@ local LSMOptionsKeyToZO_ComboBoxOptionsKey = {
 	["headerCollapsed"] = 		"headerCollapsed",
 	["headerColor"] =			"headerColor",
 	["headerFont"] =			"headerFont",
+	["headerIcon"] = 			"headerIcon",
 	["highlightContextMenuOpeningControl"] = "highlightContextMenuOpeningControl",
 	["maxNumSelections"] =		"m_maxNumSelections",
 	["maxNumSelectionsErrorText"] = "m_overrideMaxSelectionsErrorText",
@@ -779,6 +781,7 @@ local submenuClass_exposedVariables = {
 	-- LibScrollableMenu
 	["headerCollapsed"] = false,		--Header: Currently not available separately for a submenu
 	["headerCollapsible"] = false, 		--Header: Currently not available separately for a submenu
+	["headerIcon"] = false, 			--Header: Currently not available separately for a submenu
 	---------------------------------------
 	["disableFadeGradient"] = true,
 	["headerFont"] = true,

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -141,7 +141,33 @@ local function test()
 			--subtitleText = "Custom sub title",
 			enableFilter = function() return true end,
 			headerCollapsible = true,
-			headerCollapsed = true,
+			--headerCollapsed = function() return false end,
+			headerToggleTooltip = function(state)
+				if state == BSTATE_PRESSED then
+					return "Click to expand and show the search editbox"
+				else
+					return GetString(SI_ITEM_SETS_BOOK_HEADER_COLLAPSE)
+				end
+			end,
+			headerCollapsedIcon = function() return {
+				iconTexture="/esoui/art/miscellaneous/search_icon.dds",
+				width=24,
+				height=24,
+				--iconTint=CUSTOM_HIGHLIGHT_TEXT_COLOR,
+				align = LEFT,
+				offsetX = 20,
+				offSetY = 0,
+			} end,
+			--[[
+			headerCollapsedTitle = {
+				text = "Click me to show the search",
+				color = HEADER_TEXT_COLOR_RED,
+				--font = "ZO_Game"
+				align = RIGHT,
+				offsetX = -10,
+				offSetY = 0,
+			},
+			]]
 
 			--customFilterFunc = customFilterFunc
 


### PR DESCRIPTION
-Updated ESOUI description
[Added]
#2025_63 Add options.headerCollapsedIcon and options.headerCollapsedTitle --		table headerCollapsedIcon				table or function returning a table of signature { iconTexture = "path/to/textureName.dds", iconTint=ZO_ColorDef, width=number, height=number, align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Icon shown as the header is collapsed (e.g. a magnifying glass to show you can expand it to get a search). Default value is nil. Height is capped at 32! --		table headerCollapsedTitle				table or function returning a table of signature { text = "Click to search", color=ZO_ColorDef, font="FontNameHere", align=LEFT|CENTER(default)|RIGHT, offSetX=12, offSetY=-12 }: Title text shown as the header is collapsed (e.g. a text to show you can expand the section and see the search). Default value is nil. #2025_64 options.headerToggleTooltip
--		string headerToggleTooltip				String or function returning a string: Tooltip text for the collapse/expand buttons. Function signature function(state). Default: returns "Collapse"/"Expand" strings from vanilla ESOUI, depending on the current state