### PR TITLE
LSM v2.41 + 2.42

### DIFF
--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,28 +5,28 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.41
-## AddOnVersion: 020401
+## Version: 2.42
+## AddOnVersion: 020402
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
-## APIVersion: 101048 101049
+## APIVersion: 101049 101050
 ## OptionalDependsOn: LibCustomMenu LibDebugLogger
 ## SavedVariables: LibScrollableMenu_SavedVars
 
-##Language files
+; Language files
 lang/en.lua
 lang/$(language).lua
 
-##Constants
+; Constants
 constants.lua
 
-##Debugging
+; Debugging
 debug/LSM_debug.lua
 
-##Utility functions
+; Utility functions
 code/LSM_Util.lua
 
-##Classes for the LSM comboBoxes
+; Classes for the LSM comboBoxes
 classes/dropdown_class.lua
 classes/buttonGroup_class.lua
 classes/comboBox_base.lua
@@ -34,16 +34,16 @@ classes/comboBox_class.lua
 classes/submenu_class.lua
 classes/contextMenu_class.lua
 
-##LSM code and functions
+; LSM code and functions
 code/LibScrollableMenu.lua
 
-##LSM XML UI and virtual templates (row, selection, dropdowns, combobox, header, ...)
+; LSM XML UI and virtual templates (row, selection, dropdowns, combobox, header, ...)
 XML/LibScrollableMenu.xml
 
 ## API functions of this library
 LSM_API.lua
 
-## Uncomment test/LSM_test.lua to test the combobox with different menu entryTypes and submenus
-## Use slash command /lsmtest to show the test UI
-## Inspect the code in LSM_test.lua file to see how the API functions, data tables, handlers, callbacks etc. work
-test/LSM_test.lua
+; Uncomment test/LSM_test.lua to test the combobox with different menu entryTypes and submenus
+; Use slash command /lsmtest to show the test UI
+; Inspect the code in LSM_test.lua file to see how the API functions, data tables, handlers, callbacks etc. work
+; test/LSM_test.lua

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,3 +1,9 @@
+-v- ---------------LSM v2.42 - 2026-04-30--------------------------------------------------------------------------- -v-
+[Fixed]
+--#2026_07 Pattern parsing error if search term in filter header editBox was using non-escaped special character like (
+--#2026_08 ContextMenu at a slider / editbox does not open if right clicked on the name label (or the label at the right side of the slider)
+
+
 -v- ---------------LSM v2.41 - 2026-02-23--------------------------------------------------------------------------- -v-
 [KNOWN PROBLEMS]
 #2026_01 After a LSM contextMenu was shown and a checkbox was clicked (on the checkbox's label!), the next opened contextMenu's checkbox label

--- a/LibScrollableMenu/classes/comboBox_base.lua
+++ b/LibScrollableMenu/classes/comboBox_base.lua
@@ -73,6 +73,8 @@ local itemTextsOfNothingFound = {
 	[noEntriesSubmenuResultsText] = true,
 	[noEntriesResultsText] = true,
 }
+local editBoxCtrlsContextmenuRegistered = {} --#2026_08
+local sliderCtrlsContextmenuRegistered = {} --#2026_08
 
 local libUtil = lib.Util
 local getControlName = libUtil.getControlName
@@ -103,7 +105,7 @@ local iconNewIcon = textureConstants.iconNewIcon
 local iconNarrationNewValue = narrationConstants.iconNarrationNewValue
 
 local g_contextMenu
-
+local clearCustomScrollableMenu
 
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -119,7 +121,8 @@ local g_contextMenu
 -->Attention: prefix "/" in the filterString still jumps this function for submenus as non-matching will be always found that way!
 local function defaultFilterFunc(p_item, p_filterString)
 	local name = p_item.label or p_item.name
-	return zostrlow(name):find(p_filterString) ~= nil
+	local filterStringClean = p_filterString:gsub("([^%w])", "%%%1")  --#2026_07 string pattern error if search text contains a (, e.g. d(
+	return zostrlow(name):find(filterStringClean) ~= nil
 end
 
 
@@ -619,7 +622,8 @@ local function closeContextMenuAndSuppressClickCheck(checkOnlyMultiSelectionAtCo
 	if not checkOnlyMultiSelectionAtContextMenu or (checkOnlyMultiSelectionAtContextMenu and g_contextMenu.m_enableMultiSelect == true) then
 		if not isMouseOverOwningDropdown and not clickedEntryBelongsToContextMenu then --#2025_19 How to prevent context menu close if multiselection is enabled and we clicked an entry which is not above any LSM combobox, but belongs to the actual contextmenu?
 			--d(">>context menu is opened and clicked somewhere else -> Hide the contextMenu now")
-			ClearCustomScrollableMenu()
+			clearCustomScrollableMenu = clearCustomScrollableMenu or ClearCustomScrollableMenu
+			clearCustomScrollableMenu()
 			--20250309 Prevent the next dropdownClass:OnEntryMouseUp being fired if we clicked inside an LSM (only the contextMenu should close!)
 			--d("1!!! Setting suppressNextOnEntryMouseUp = true !!!")
 			lib.preventerVars.suppressNextOnEntryMouseUp = true
@@ -635,7 +639,8 @@ local function closeContextMenuAndSuppressClickCheck(checkOnlyMultiSelectionAtCo
 		-->E.g. a submenu entry of a LSM
 		if not isMouseOverOwningDropdown and not clickedEntryBelongsToContextMenu then
 			--d(">>context menu is opened and clicked somewhere else, e.g. submenu -> Hide the contextMenu now")
-			ClearCustomScrollableMenu()
+			clearCustomScrollableMenu = clearCustomScrollableMenu or ClearCustomScrollableMenu
+			clearCustomScrollableMenu()
 			--20250309 Prevent the next dropdownClass:OnEntryMouseUp being fired if we clicked inside an LSM (only the contextMenu should close!)
 			--d("2!!! Setting suppressNextOnEntryMouseUp = true !!!")
 			lib.preventerVars.suppressNextOnEntryMouseUp = true
@@ -2013,7 +2018,7 @@ do -- Row setup functions
 		local editBoxData = control.editBoxData
 		if type(editBoxData) ~= "table" then return end
 
-		--local labelCtrl  = control.m_label
+		local labelCtrl  = control.m_label
 		local editCtrl = control:GetNamedChild("Edit")
 		local editBoxCtrl = editCtrl:GetNamedChild("Box")
 		editBoxCtrl.rowControl = control --reference to the actual row's control having the m_data table
@@ -2022,23 +2027,40 @@ do -- Row setup functions
 		updateEditBoxText(control, editBoxData, editBoxCtrl)
 
 		----EditBox - HANDLERS
+		labelCtrl:SetMouseEnabled(false) --#2026_08
 		--contextMenuCallback -- ContextMenu at the editBox
 		local contextMenuCallback = editBoxData.contextMenuCallback
 		if type(contextMenuCallback) == "function" then
+			local function showEditBoxContextMenu(p_editBox)
+				ZO_Tooltips_HideTextTooltip()
+				--Show the contextMenu now
+				contextMenuCallback(p_editBox)
+			end
+
 			editBoxCtrl:SetMouseEnabled(true)
 			editBoxCtrl:SetHandler("OnMouseUp", nil)
 			editBoxCtrl:SetHandler("OnMouseUp", function(p_editBox, button, upInside, ctrl, alt, shift)
 				if button == MOUSE_BUTTON_INDEX_RIGHT and upInside then
 					--Remove the cursor from the editbox
-					p_editBox:LoseFocus()
-					--Show the contextMenu now
-					contextMenuCallback(p_editBox)
+					showEditBoxContextMenu(p_editBox)
 				end
 			end)
+
+			labelCtrl:SetMouseEnabled(true) --#2026_08
+			if not editBoxCtrlsContextmenuRegistered[editBoxCtrl] then --#2026_08
+				editBoxCtrlsContextmenuRegistered[editBoxCtrl] = true
+				labelCtrl:SetHandler("OnMouseUp", function(p_editBox, button, upInside, ctrl, alt, shift)
+					if not upInside then return end
+					if button == MOUSE_BUTTON_INDEX_RIGHT then
+						showEditBoxContextMenu(p_editBox)
+					end
+				end)
+			end
+
 		end
 
 		--EditBox & label Dimensions width/height etc.
-		--Slightly delay this so the controls are updated properly before (e.g. row's width)
+		--Slightly delay this to next frame so the controls are updated properly before (e.g. row's width)
 		zo_callLater(function()
 			reAnchorEditBoxControlsInRow(control)
 		end, 0)
@@ -2144,16 +2166,14 @@ do -- Row setup functions
 		end
 
 		local offsetX = (hideLabel == true and 0) or 4
+		sliderCtrl:ClearAnchors()
+		sliderCtrl:SetAnchor(LEFT, labelCtrl, RIGHT, offsetX)
 		if widthOrHeightChanged == true then
-			sliderCtrl:ClearAnchors()
 			sliderCtrl:SetDimensionConstraints(0, 0, width, height)
 			sliderCtrl:SetDimensions(width, height)
-			sliderCtrl:SetAnchor(LEFT, labelCtrl, RIGHT, offsetX)
 		else
-			sliderCtrl:ClearAnchors()
 			sliderCtrl:SetDimensionConstraints(20, 5, width, height)
 			sliderCtrl:SetDimensions(width, height)
-			sliderCtrl:SetAnchor(LEFT, labelCtrl, RIGHT, offsetX)
 		end
 	end
 
@@ -2162,7 +2182,7 @@ do -- Row setup functions
 		local sliderData = control.sliderData
 		if type(sliderData) ~= "table" then return end
 
-		--local labelCtrl  = control.m_label
+		local labelCtrl  = control.m_label
 		local sliderContainerCtrl = control:GetNamedChild("SliderContainer")
 		local sliderCtrl = sliderContainerCtrl:GetNamedChild("Slider")
 		sliderCtrl.rowControl = control --reference to the actual row's control having the m_data table
@@ -2231,17 +2251,39 @@ do -- Row setup functions
 			contextMenuCallback = nil
 		end
 
+		local sliderGotContextMenu = contextMenuCallback ~= nil --#2026_08
+		local function showSliderContextMenu(p_sliderCtrl) --#2026_08
+			if not sliderGotContextMenu then return end
+			ZO_Tooltips_HideTextTooltip()
+			contextMenuCallback(p_sliderCtrl)
+		end
+		labelCtrl:SetMouseEnabled(sliderGotContextMenu) --#2026_08
+		sliderValueLabel:SetMouseEnabled(sliderGotContextMenu) --#2026_08
+		if sliderGotContextMenu == true and not sliderCtrlsContextmenuRegistered[sliderCtrl] then --#2026_08
+			sliderCtrlsContextmenuRegistered[sliderCtrl] = true
+			labelCtrl:SetHandler("OnMouseUp", function(p_sliderCtrl, button, upInside, ctrl, alt, shift)
+				if not upInside then return end
+				if button == MOUSE_BUTTON_INDEX_RIGHT then
+					showSliderContextMenu(p_sliderCtrl)
+				end
+			end)
+			sliderValueLabel:SetHandler("OnMouseUp", function(p_sliderCtrl, button, upInside, ctrl, alt, shift)
+				if not upInside then return end
+				if button == MOUSE_BUTTON_INDEX_RIGHT then
+					showSliderContextMenu(p_sliderCtrl)
+				end
+			end)
+		end
+
+
 		--Left click/right click contextMenu
 		local function onSliderMouseUp(p_sliderCtrl, button, upInside, ctrl, alt, shift)
-			if button == MOUSE_BUTTON_INDEX_RIGHT and upInside then
-				if contextMenuCallback == nil then return end
-				ZO_Tooltips_HideTextTooltip()
-				contextMenuCallback(p_sliderCtrl)
+			if not upInside then return end
+			if button == MOUSE_BUTTON_INDEX_RIGHT then
+				showSliderContextMenu(p_sliderCtrl)
 			elseif button == MOUSE_BUTTON_INDEX_LEFT then
 				sliderValueLabel:SetText((showSliderValueLabel == true and tos(p_sliderCtrl:GetValue())) or "")
-				if upInside then
-					sliderOnMouseEnter(p_sliderCtrl)
-				end
+				sliderOnMouseEnter(p_sliderCtrl)
 			end
 		end
 
@@ -2256,7 +2298,7 @@ do -- Row setup functions
 		end
 
 		--Slider & label Dimensions width/height etc.
-		-->Slightly delay this so the controls update properly before (e.g. row's width)
+		-->Slightly delay this to next frame so the controls update properly before (e.g. row's width)
 		zo_callLater(function()
 			reAnchorSliderControlsInRow(control)
 		end, 0) --#2025_40 delay to next frame to update row's width properly first

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -107,7 +107,7 @@ local libUtil_BelongsToContextMenuCheck = libUtil.belongsToContextMenuCheck
 local libUtil_checkIfValidTexturePath   = libUtil.checkIfValidTexturePath
 
 local preventCustomScrollableContextMenuHide
-
+local clearCustomScrollableMenu
 
 --locals
 local isBoolean = {
@@ -2343,7 +2343,8 @@ function dropdownClass:ResetFilters(owningWindow)
 	if self.m_comboBox ~= nil then
 		if not self.m_comboBox.isContextMenu then --#2025_23 replaced by self.m_comboBox.isContextMenu -> self.m_comboBox.openingControl == nil then
 			--d(">>calling ClearCustomScrollableMenu")
-			ClearCustomScrollableMenu()
+			clearCustomScrollableMenu = clearCustomScrollableMenu or ClearCustomScrollableMenu
+			clearCustomScrollableMenu()
 		end
 	end
 

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -29,7 +29,7 @@ local checkNextOnEntryMouseUpShouldExecute = libUtil.checkNextOnEntryMouseUpShou
 local playSelectedSoundCheck = libUtil.playSelectedSoundCheck
 
 local g_contextMenu
-
+local clearCustomScrollableMenu
 
 --------------------------------------------------------------------
 -- For debugging and logging
@@ -57,7 +57,8 @@ local function hideCurrentlyOpenedLSMAndContextMenu()
 --d("[LSM]hideCurrentlyOpenedLSMAndContextMenu")
 	local openMenu = lib.openMenu
 	if openMenu and openMenu:IsDropdownVisible() then
-		ClearCustomScrollableMenu()
+		clearCustomScrollableMenu = clearCustomScrollableMenu or ClearCustomScrollableMenu
+		clearCustomScrollableMenu()
 		openMenu:HideDropdown()
 	end
 end
@@ -220,7 +221,8 @@ local function onAddonLoaded(event, name)
 	--Register a scene manager callback for the SetInUIMode function so any menu opened/closed closes the context menus of LSM too
 	SecurePostHook(SCENE_MANAGER, 'SetInUIMode', function(self, inUIMode, bypassHideSceneConfirmationReason)
 		if not inUIMode then
-			ClearCustomScrollableMenu()
+			clearCustomScrollableMenu = clearCustomScrollableMenu or ClearCustomScrollableMenu
+			clearCustomScrollableMenu()
 		end
 	end)
 
@@ -279,58 +281,33 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.41 - Updated 2026-02-23
+	CHANGELOG Current version: 2.42 - Updated 2026-04-30
 ---------------------------------------------------------------
-Max error #: 2026_07
+Max error #: 2026_08
+
+[WORKING ON]
+
+
 
 [FEATURE]
 
+
+--======================================================================================================================
 [KNOWN PROBLEMS]
-#2026_01 After a LSM contextMenu was shown and a checkbox was clicked (on the checkbox's label!), the next opened contextMenu's checkbox label
+--======================================================================================================================
+--#2026_01 After a LSM contextMenu was shown and a checkbox was clicked (on the checkbox's label!), the next opened contextMenu's checkbox label
   is not changing the checkbox state (as if the first click is not accepted?), only the 2nd click does. (noticed during BMU LCM -> LSM changes at 2026-01-25)
-#2026_03 Search header contextMenu for last searched does not work on BeamMeUp item filter header?
-#2026_07 If you enter a search in the contextMenu header editbox which uses specal characters like a (, e.g. d(, you get this error:
-	pattern parsing error
-	|rstack traceback:
-	[C]: in function 'string.find'
-	user:/AddOns/LibScrollableMenu/classes/comboBox_base.lua:122: in function 'defaultFilterFunc'
-	|caaaaaa<Locals> p_item = [table:1]{name = "Row actions - #15", isNew = F, font = "ZoFontGame", isDivider = F, hasSubmenu = F, isCheckbox = F, isButton = F, customEntryTemplate = "LibScrollableMenu_ComboBoxHead...", enabled = T, entryType = 3, isRadioButton = F, isHeader = T}, p_filterString = "d(", name = "Row actions - #15" </Locals>|r
-	user:/AddOns/LibScrollableMenu/classes/dropdown_class.lua:611: in function 'filterResults'
-	|caaaaaa<Locals> item = [table:1], comboBox = [table:2]{enableFilter = T, optionsChanged = T, m_name = "LibScrollableMenu_ContextMenu...", multiSelectionTextFormatter = 910, isContextMenu = T, m_sortOrder = T, filterString = "d(", itemYPad = 0, breadcrumbName = "ContextmenuBreadcrumb", automaticSubmenuRefresh = F, disableFadeGradient = F, headerCollapsible = T, m_containerWidth = 264.95202636719, currentSelectedItemText = "", m_isDropdownVisible = T, m_font = "ZoFontGame", m_enableMultiSelect = F, automaticRefresh = F, m_maxNumSelectionsErrorText = "Maximum selections reached.", m_nextFree = 2, headerFont = "ZoFontGame", m_highlightTemplate = "ZO_SelectionHighlight", noSelectionText = "No Entries Selected", visibleRowsSubmenu = 15, m_sortsItems = F, horizontalAlignment = 0, baseEntryHeight = 25, m_spacing = 0, visibleRows = 15, containerMinWidth = 50, headerCollapsed = F, m_height = 437}, dropdownObject = [table:3]{nextScrollTypeId = 21, spacing = 0}, entryType = 3, doNotFilter = F, doSearch = T </Locals>|r
-	user:/AddOns/LibScrollableMenu/code/LSM_Util.lua:240: in function 'libUtil.recursiveOverEntries'
-	|caaaaaa<Locals> entry = [table:1], comboBox = [table:2], callback = user:/AddOns/LibScrollableMenu/classes/dropdown_class.lua:576 </Locals>|r
-	(tail call): ?
-	user:/AddOns/LibScrollableMenu/classes/dropdown_class.lua:2047: in function 'dropdownClass:Show'
-	|caaaaaa<Locals> self = [table:3], comboBox = [table:2], itemTable = [table:4]{}, minWidth = 50, maxWidth = 264.95202636719, maxHeight = 437, spacing = 0, comboBoxObject = [table:2], textSearchEnabled = T, control = ud, scrollControl = ud, numItems = 21, largestEntryWidth = 0, dataList = [table:5]{}, allItemsHeight = 52, anyItemMatchesFilter = F, i = 1, item = [table:1], isLastEntry = F </Locals>|r
-	user:/AddOns/LibScrollableMenu/classes/comboBox_base.lua:1629: in function 'comboBox_base:Show'
-	|caaaaaa<Locals> self = [table:2] </Locals>|r
-	user:/AddOns/LibScrollableMenu/classes/comboBox_class.lua:445: in function 'comboBoxClass:UpdateResults'
-	|caaaaaa<Locals> self = [table:2], comingFromFilters = T </Locals>|r
-	user:/AddOns/LibScrollableMenu/classes/comboBox_class.lua:234: in function 'comboBoxClass:SetFilterString'
-	|caaaaaa<Locals> self = [table:2], filterBox = ud, newText = "d(" </Locals>|r
-	user:/AddOns/LibScrollableMenu/classes/dropdown_class.lua:2280: in function 'callback'
-	|caaaaaa<Locals> text = "d(" </Locals>|r
-	user:/AddOns/LibScrollableMenu/code/LSM_Util.lua:641: in function '(anonymous)'
+
+--#2026_03 Search header contextMenu for last searched does not work on BeamMeUp item filter header?
+
+--======================================================================================================================
 
 
 [Fixed]
---#2026_02 Nil error at combobox header collapsed state SavedVariables
---#2026_04 Added missing additonalData to API function AddCustomScrollableSubMenuEntry
---#2026_05 API function lib.ButtonGroupDefaultContextMenu / lib.SetButtonGroupState got a new 4th param "use_ZO_Menu" which, if set true, will make the contextMenu
---at the checkbox/radiobutton group just use ZO_Menu instead of LSM contextMenu. It autodetects that: If a LSM contextMenu is already shown, ZO_Menu will be used automatically.
---This allows ZO_Menu contextMenu with "Select all"/"Deselect all"/"Invert" at any LSM contextMenu entry's data.contextMenuCallback function
+--#2026_07 Pattern parsing error if search term in filter header editBox was using non-escaped special character like (
+--#2026_08 ContextMenu at a slider / editbox does not open if right clicked on the name label (or the label at the right side of the slider)
 
 [Added]
---#2026_06 control.closeOnSelect must be passed in from additionalData.closeOnSelect so normal (submenu) entries can keep an LSM oepned, even if selectable and clicked
-
-New API functions:
---API to keep the LSM opened even if a contextMenu is opened (via ZO_Menu e.g.)
-function PreventCustomScrollableContextMenuHide()
-
---API to keep the LSM opened even if a contextMenu (at a ZO_Menu contextMenu showing above an LSM entry e.g.) entry was clicked
---Mandatory parameter clickCount controls how many clicks it will stay open
-function PreventCustomScrollableContextMenuEntryClickHide(clickCount)
-
 
 [Changed]
 
@@ -340,11 +317,7 @@ function PreventCustomScrollableContextMenuEntryClickHide(clickCount)
 ---------------------------------------------------------------
 TODO - To check (future versions)
 ---------------------------------------------------------------
-	1. Optionally: Make Options update same style like updateDataValues does for entries
-	2. Attention: zo_comboBox_base_hideDropdown(self) in self:HideDropdown() does NOT close the main dropdown if right clicked! Only for a left click... See ZO_ComboBox:HideDropdownInternal()
-	3. verify submenu anchors. Small adjustments not easily seen on small laptop monitor
-	- fired on handlers dropdown_OnShow dropdown_OnHide
-	4. If header is enabled and the filter is enabled, you right clicked the editbox of the filter header, and choose an entry: Next left click outside does not close the opened dropdown)
+
 
 ---------------------------------------------------------------
 UPCOMING FEATURES  - What could be added in the future?

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -6,7 +6,7 @@ if LibScrollableMenu ~= nil then return end -- the same or newer version of this
 local lib = ZO_CallbackObject:New()
 lib.name = "LibScrollableMenu"
 lib.author = "Baertram, IsJustaGhost, tomstock, Kyoma"
-lib.version = "2.41"
+lib.version = "2.42"
 if not lib then return end
 --------------------------------------------------------------------
 

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -743,6 +743,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 					showValueLabel = 		true,
 					--valueLabelFont = 		"ZoFontWinH3",
 					hideValueTooltip = 		true,
+					--[[
 					contextMenuCallback = 	function(self)
 						d("--> ContextMenu at Slider")
 						ClearCustomScrollableMenu()
@@ -751,6 +752,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 						AddCustomScrollableMenuSlider("Slider context", function() d("Changed slider at context") end, { min=1, max=5, step=0.5, width="85%", labelWidth="10%" }, nil)
 						ShowCustomScrollableMenu()
 					end
+					]]
 				}
 			},
 			{
@@ -787,6 +789,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 					--textType = 			TEXT_TYPE_NUMERIC_UNSIGNED_INT,
 					font = 					"ZoFontChat",
 					--width = 				"100%",
+					--[[
 					contextMenuCallback = 	function(self)
 						d("--> ContextMenu at EditBox")
 						ClearCustomScrollableMenu()
@@ -794,6 +797,7 @@ d(debugPrefix .. "Context menu submenu 2 - Custom menu 2 Normal entry 1->RunCust
 						AddCustomScrollableMenuRadioButton("Radio button2 at context", function() d("clicked radio button2 at context") end, true, 1, nil)
 						ShowCustomScrollableMenu()
 					end
+					]]
 				}
 			},
 			{


### PR DESCRIPTION
--#2026_07 Pattern parsing error if search term in filter header editBox was using non-escaped special character like ( --#2026_08 ContextMenu at a slider / editbox does not open if right clicked on the name label (or the label at the right side of the slider)