### PR TITLE
LSM v2.4.3 fixes

### DIFF
--- a/ESOUI_description.txt
+++ b/ESOUI_description.txt
@@ -50,6 +50,7 @@ But using both on the same control in combination won't work.
 
 [u]Developer reference[/u]
 Read the Github readme file and check file LSM_test.lua for example code, and the LSM_API.lua file please.
+Example: [url="https://wiki.esoui.com/How_to_create_a_scrollable_context_menu"]https://wiki.esoui.com/How_to_create_a_scrollable_context_menu[/URL]
 
 
 Add a scrolhelper (dropdown scrollable) to a ZO_ComboBox:
@@ -444,7 +445,7 @@ LibScrollableMenu's API functions AddCustomScrollableMenuEntry and AddCustomScro
 
 
 [u]GitHub[/u]
-https://github.com/tomstock1337/eso-LibScrollableMenu
+[URL="https://github.com/tomstock1337/eso-LibScrollableMen"]https://github.com/tomstock1337/eso-LibScrollableMenu[/URL]
 
 [U]Planned features[/U]
 -Support for LibCustomMenu (replace it and ZO_Menu e.g. at inventory rows)

--- a/LibScrollableMenu/LSM_API.lua
+++ b/LibScrollableMenu/LSM_API.lua
@@ -294,6 +294,7 @@ GetCustomScrollableMenuRowData = libUtil.getControlData
 --)
 ---> returns nilable:number indexOfNewAddedEntry, nilable:table newEntryData
 function AddCustomScrollableMenuEntry(text, callback, entryType, entries, additionalData)
+--d(debugPrefix .. "AddCustomScrollableMenuEntry - text: " .. tos(text) .. ", type: " ..tos(entryType) .. ", entries: " ..tos(entries))
 	--Special handling for dividers
 	updateContextMenuRef()
 	local options = g_contextMenu:GetOptions()
@@ -571,8 +572,8 @@ end
 function ShowCustomScrollableMenu(controlToAnchorTo, options, specialCallbackData) --#2025_45
 	updateContextMenuRef()
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_DEBUG, 171, tos(getControlName(controlToAnchorTo)), tos(options)) end
-	--d("°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°")
-	--df(debugPrefix.."_-_-_-_-_ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
+--d("°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°")
+--df(debugPrefix.."_-_-_-_-_ShowCustomScrollableMenu - controlToAnchorTo: %s, options: %s", tos(getControlName(controlToAnchorTo)), tos(options))
 
 	--[[
 	--#2025_22 Check if the openingControl is another contextMenu -> We cannot show a contextMenu on a contextMenu
@@ -756,7 +757,11 @@ RefreshCustomScrollableMenu = LSM_RefreshLibScrollableMenu
 local function LSM_IsContextMenuCurrentlyShown()
 	g_contextMenu = updateContextMenuRef()
 	if g_contextMenu == nil then return false end
-	return g_contextMenu:IsDropdownVisible()
+	local isDropdownVisible = g_contextMenu:IsDropdownVisible()
+	if not isDropdownVisible then
+		isDropdownVisible = g_contextMenu.m_dropdownObject.control:IsHidden() --#2026_13
+	end
+	return isDropdownVisible
 end
 IsCustomScrollableContextMenuShown = LSM_IsContextMenuCurrentlyShown --#2025_59
 

--- a/LibScrollableMenu/LibScrollableMenu.txt
+++ b/LibScrollableMenu/LibScrollableMenu.txt
@@ -5,8 +5,8 @@
 
 ## Title: LibScrollableMenu
 ## Description: Adds scrollable menu&nested submenus functionality to combobox. Originally developed by Kyoma's Titlizer
-## Version: 2.43
-## AddOnVersion: 020403
+## Version: 2.44
+## AddOnVersion: 020404
 ## IsLibrary: true
 ## Author: IsJustaGhost, Baertram, tomstock (, Kyoma)
 ## APIVersion: 101049 101050
@@ -46,4 +46,4 @@ LSM_API.lua
 ; Uncomment test/LSM_test.lua to test the combobox with different menu entryTypes and submenus
 ; Use slash command /lsmtest to show the test UI
 ; Inspect the code in LSM_test.lua file to see how the API functions, data tables, handlers, callbacks etc. work
-;test/LSM_test.lua
+test/LSM_test.lua

--- a/LibScrollableMenu/XML/LibScrollableMenu.xml
+++ b/LibScrollableMenu/XML/LibScrollableMenu.xml
@@ -1,13 +1,5 @@
 <GuiXml>
 	<Controls>
-		<!-- Munge template -->
-			<!--Controls>
-				<Texture name="$(parent)MungeOverlay" textureFile="EsoUI/Art/Tooltips/munge_overlay.dds" layer="CONTROLS" level="1" addressMode="WRAP" hidden="false">
-					<Anchor point="TOPLEFT" offsetY="1" />
-					<Anchor point="BOTTOMRIGHT" offsetY="-2" />
-				</Texture>
-			</Controls-->
-			
 		<!-- Highlight for ZO_SortFilterList entries where a submenu got a callback function - Light green
 			Normal highlight is ZO_SelectionHighlight  -light blue -->
 		<Backdrop name="LibScrollableMenu_Highlight_Green" inherits="ZO_SelectionHighlight" virtual="true" blendMode="ADD" centerColor="00ff00" edgeColor="00ff00"/>

--- a/LibScrollableMenu/changelog.txt
+++ b/LibScrollableMenu/changelog.txt
@@ -1,9 +1,16 @@
+-v- ---------------LSM v2.44 - 2026-06-06--------------------------------------------------------------------------- -v-
+[Fixed]
+--#2026_01 1st click on a checkbox/radio button in a new opened contextMenu, after another contextMenu was opened before and a checkbox/radiobutton was clicked inside, did not work
+--#2026_11 Opening a contextMenu from a non LSM control (e.g. custom button to show the contextMenu on) showed the contextMenu empty, if another LSM non-contextMenu dropdown was opened at that time)
+--#2026_13 Opening a contextmenu sometimes made it vanish behind the openingControl, due to the automatic (sub)menuRefreshs (if enabled)
+--#2026_14 Checkboxes/Radiobuttons clicked in opened submenus closed the submenus sometimes
+
+
 -v- ---------------LSM v2.43 - 2026-05-27--------------------------------------------------------------------------- -v-
 [Added]
 --#2026_09 Custom sorting default values (customSortKey: applied once as the LSM is initialized), and a custom sort function customSortFunc, signature function(table entry1, table entry2, table:nilable comboboxObject): return boolean
 --#2026_10 options.enableSort Show ^v sort header icons at the dropdown (collapsible) header -> Only if enableFilter == true, and not working at contextMenus or submenus
 --#2026_12 Adding nilable:table options.customSortDownButton = { nilable:table dimensions = { number x = 18, number y = 18 }, nilable:table texture = { up = "", normal = "", pressed = "", disabled = "" }, nilable:table anchor = { number:pointOnMe = LEFT, target = userdata:control, number:pointOnTarget = LEFT, nilable:number offsetX = 0, nilable:number offsetY = 0 }, and options.customSortUpButton
-
 
 -v- ---------------LSM v2.42 - 2026-04-30--------------------------------------------------------------------------- -v-
 [Fixed]
@@ -24,7 +31,7 @@
 --This allows ZO_Menu contextMenu with "Select all"/"Deselect all"/"Invert" at any LSM contextMenu entry's data.contextMenuCallback function
 
 [Added]
---#2026_06 control.closeOnSelect must be passed in from additionalData.closeOnSelect so normal (submenu) entries can keep an LSM oepned, even if selectable and clicked
+--#2026_06 control.closeOnSelect must be passed in from additionalData.closeOnSelect so normal (submenu) entries can keep an LSM opened, even if selectable and clicked
 
 New API functions:
 --API to keep the LSM opened even if a contextMenu is opened (via ZO_Menu e.g.)

--- a/LibScrollableMenu/classes/comboBox_base.lua
+++ b/LibScrollableMenu/classes/comboBox_base.lua
@@ -1012,6 +1012,8 @@ function comboBox_base:OnGlobalMouseUp(eventId, button)
 		moc = moc(),
 	}
 	]]
+
+	--Check if any particular mouse button was set to be sekipped in next global mouse up event, or if any mouse button should be skipped once
 	local abortEarly = false
 	local suppressNextOnGlobalMouseUp = lib.preventerVars.suppressNextOnGlobalMouseUp
 	local suppressNextOnGlobalMouseUpType = suppressNextOnGlobalMouseUp ~= nil and type(suppressNextOnGlobalMouseUp) or nil
@@ -1019,12 +1021,13 @@ function comboBox_base:OnGlobalMouseUp(eventId, button)
 		--Supress all next clicks (boolean true)
 		if suppressNextOnGlobalMouseUpType == "boolean" and suppressNextOnGlobalMouseUp == true then
 			abortEarly = true
-			--Supress only e.g. a left click, but not a right click?
+		--Supress only e.g. a left click, but not a right click?
 		elseif suppressNextOnGlobalMouseUpType == "number" and suppressNextOnGlobalMouseUp == button then
 			abortEarly = true
 		end
 	end
 	if abortEarly then
+--d("< < ABORT: due to suppressNextOnGlobalMouseUp!")
 		lib.preventerVars.suppressNextOnGlobalMouseUp = nil
 		return false
 	end
@@ -1035,16 +1038,16 @@ function comboBox_base:OnGlobalMouseUp(eventId, button)
 		if not isMouseOverOwningDropdown then
 --d(">>dropdownVisible -> NO IsMouseOverControl") --#2025_19 Closes a context menu if the clicked entry of the contextmenu was not above the LSM anymore -> Should not directly close if multiselection is enabled in the context menu!
 			if self:HiddenForReasons(button, isMouseOverOwningDropdown) then
-				--d(">>>HiddenForReasons -> Hiding dropdown now")
+--d(">>>HiddenForReasons -> Hiding dropdown now")
 				return self:HideDropdown()
 			end
 		end
 	else
 		if self.m_container:IsHidden() then
-			--d(">>>else - containerIsHidden -> Hiding dropdown now")
+--d(">>>else - containerIsHidden -> Hiding dropdown now")
 			self:HideDropdown()
 		else
-			--d("<SHOW DROPDOWN OnMouseUp")
+--d("<SHOW DROPDOWN OnMouseUp")
 			lib.openMenu = self
 			-- If shown in ShowDropdownInternal, the global mouseup will fire and immediately dismiss the combo box. We need to
 			-- delay showing it until the first one fires.
@@ -1181,11 +1184,12 @@ end
 --return false:	Do not hide the combobox
 --return true: Hide the comboBox
 function comboBox_base:HiddenForReasons(button, isMouseOverOwningDropdown)
+--d(debugPrefix .. "comboBox_base:HiddenForReasons - isMouseOverOwningDropdown: " ..tos(isMouseOverOwningDropdown))
 	g_contextMenu = getContextMenuReference()
 	local owningWindow, mocCtrl, comboBox, mocEntry = getMouseOver_HiddenFor_Info()
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 96, tos(button)) end
 
-	--is the mocCtrl a checkbox of a checkBox row -> then get the parent = the row
+	--is the mocCtrl e.g. a checkbox of a checkBox row (or a radiobutton, editbox, slider, ... -> See table isEntryTypeWithParentMocCtrl): then get the parent = the row
 	local mocCtrlOrig = mocCtrl
 	if mocCtrl ~= nil and mocCtrl.m_owner == nil then
 		if (mocCtrl.entryType ~= nil and isEntryTypeWithParentMocCtrl[mocCtrl.entryType]) or mocCtrl.toggleFunction then
@@ -2620,6 +2624,7 @@ d(">enabled: " .. tos(data.enabled))
 		if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 121, tos(getControlName(control)), tos(list)) end
 
 		local selfVar = self
+		--Issued from ZO_CheckButton_OnClicked, which is called from lib.XML.XMLButtonOnInitialize(control, entryType)
 		local function toggleFunction(checkbox, checked)
 			local checkedData = getControlData(checkbox:GetParent())
 

--- a/LibScrollableMenu/classes/comboBox_class.lua
+++ b/LibScrollableMenu/classes/comboBox_class.lua
@@ -467,25 +467,7 @@ function comboBoxClass:ShowDropdownInternal()
 	self.m_container:RegisterForEvent(EVENT_GLOBAL_MOUSE_UP, function(...) self:OnGlobalMouseUp(...) end)
 end
 
-
-function comboBoxClass:OnGlobalMouseUp(eventCode, button)
---d("[LSM]comboBoxClass:OnGlobalMouseUp - visible: " ..tos(self:IsDropdownVisible()))
-	if self:IsDropdownVisible() then
-		if button == MOUSE_BUTTON_INDEX_LEFT and not self.m_dropdownObject:IsMouseOverControl() then
---d(">1HideDropdown now")
-			self:HideDropdown()
-		end
-	else
-		if self.m_container:IsHidden() then
---d(">2HideDropdown now")
-			self:HideDropdown()
-		else
-			-- If shown in ShowDropdownInternal, the global mouseup will fire and immediately dismiss the combo box. We need to
-			-- delay showing it until the first one fires.
-			self:ShowDropdownOnMouseUp()
-		end
-	end
-end
+--function comboBoxClass:OnGlobalMouseUp(eventCode, button) --#2026_14 20260606 See comboBox_base:OnGlobalMouseUp -> is calling self:HiddenForReasons to prevent GlobalMouseUp click handler closing opened submenus if a checkbox/radiobutton was clicked (and many more circumstances)
 
 function comboBoxClass:ShowDropdownOnMouseUp()
 --d("[LSM]comboBoxClass:ShowDropdownOnMouseUp - enabled: " ..tos(self:IsEnabled()))

--- a/LibScrollableMenu/classes/contextMenu_class.lua
+++ b/LibScrollableMenu/classes/contextMenu_class.lua
@@ -101,10 +101,11 @@ end
 -- self.data at ShowContextMenu method
  function contextMenuClass:AddContextMenuItem(itemEntry)
 	if libDebug.doDebug then dlog(libDebug.LSM_LOGTYPE_VERBOSE, 150, tos(itemEntry)) end
---d(debugPrefix .. 'contextMenuClass:AddContextMenuItem - name: ' ..tos(itemEntry.label or itemEntry.name))
-
 	local indexAdded = tins(self.data, itemEntry)
 	indexAdded = indexAdded or #self.data
+
+--d(debugPrefix .. 'contextMenuClass:AddContextMenuItem - name: ' ..tos(itemEntry.label or itemEntry.name) .. ", indexAdded: " ..tos(indexAdded))
+
 	return indexAdded
 --	m_unsortedItems
 end
@@ -202,22 +203,30 @@ function contextMenuClass:ShowContextMenu(parentControl)
 --d(debugPrefix .. "->->->->-> contextMenuClass:ShowContextMenu")
 --d(">resetting some lib.preventerVars")
 	lib.preventerVars.wasContextMenuOpenedAsOnMouseUpWasSuppressed = nil
+	lib.preventerVars.suppressNextOnEntryMouseUp = nil --#2026_01
 	lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter = nil
+	lib.preventerVars.suppressNextHideContextMenuClearItems = nil --#2026_11
 
 	--Cache last opening Control for the comparison with new openingControl and reset of filters etc. below
 	local openingControlOld = self.openingControl
 	if parentControl == nil then parentControl = self.contextMenuIssuingControl or moc() end --#2025_28
 	self.openingControl = parentControl
 
+	--#2026_11 Check if the contextMenu was opened from any LSM entry, or maybe on any custom control (settings menu button of any addon e.g.)
+	-->Is a check for self.contextMenuIssuingControl ~= nil enough for that?
+	local wasOpenedFromOtherLSMEntry = self.contextMenuIssuingControl ~= nil
+--d(">wasOpenedFromOtherLSMEntry: " ..tos(wasOpenedFromOtherLSMEntry))
 
 	-- To prevent the context menu from overlapping a submenu it is not opened from:
 	-- If the opening control is a dropdown and has a submenu visible, close the submenu.
 	local comboBox = getComboBox(parentControl)
 	if comboBox and comboBox.m_submenu and comboBox.m_submenu:IsDropdownVisible() then
+--d("-->Hiding opened submenu's dropdown")
 		comboBox.m_submenu:HideDropdown()
 	end
 
 	if self:IsDropdownVisible() then
+--d("-->Hiding opened dropdown")
 		self:HideDropdown()
 	end
     --d(">Before options: self.enableFilter = " .. tos(self.enableFilter))
@@ -243,19 +252,22 @@ function contextMenuClass:ShowContextMenu(parentControl)
 
 --d("->->->->->->-> [LSM]ContextMenuClass:ShowContextMenu -> ShowDropdown now!")
 	--Check if any non-contextMenu LSM is shown and if that is the case it's OnGlobalMouseUp will fire as it closes
-	if libUtil_isAnyLSMDropdownVisible(false) then --#2025_29
+	local otherLSMDropdownNonContextMenuVisible = libUtil_isAnyLSMDropdownVisible(false)
+	if otherLSMDropdownNonContextMenuVisible == true then --#2025_29
 --d(">supressing next onMouseUp as an LSM is still opened, and the mouse would clear the contextMenu entries")
 		lib.preventerVars.suppressNextOnGlobalMouseUp = true
 	end
 	self:ShowDropdown()
 
 
-	--#2025_29 Next OnGlobalMouse up of any before opened LSM (as we right clicked any other owningWindow's LSM entry to show a contextMenu)
+	--#2025_29 #2026_11 Next OnGlobalMouse up of any before opened LSM (as we either right clicked any other owningWindow's LSM entry [wasOpenedFromOtherLSMEntry = true], or we clicked any custom control [e.g. any buton to show a settings menu] to show a contextMenu)
 	--will fire after the contextMenu here is shown -> and these other onGlobalMouseUps will clear the contextMenu entries via libUtil.hideContextMenu again :-(
-	--todo 20250406 How can we detect this? And then prevent the globalMouseUps (there are 2 in that case: 1 from the new contextMenu's opening control and one from the before opened LSM)
+	--todo 20250406 #2026_11 How can we detect this? And then prevent the globalMouseUps (there are 2 in that case: 1 from the new contextMenu's opening control and one from the before opened LSM)
+	if not wasOpenedFromOtherLSMEntry and otherLSMDropdownNonContextMenuVisible then
+--d(">supressing next 2 HideContextMenu's ClearItems")
+		lib.preventerVars.suppressNextHideContextMenuClearItems = 2 --#2026_11 Set the next 2 g_contextMenu:ClearItems() in function libUtil.hideContextMenu() to do nothing!
+	end
 
-
-	--d(debugPrefix .. "ContextMenuClass:ShowContextMenu - openingControl changed!")
 	throttledCall(function()
 		if openingControlOld ~= parentControl then
 			--d(debugPrefix .. "ContextMenuClass:ShowContextMenu - openingControl changed!")
@@ -299,17 +311,17 @@ function contextMenuClass:UnregisterSpecialCallback(uniqueAddonName, callbackNam
 			if loopedUniqueAddonName == uniqueAddonName then
 				--No callbackname provided, means: delete all
 				if callbackName == nil then
-	d(">no callback specified, deleting all contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "]")
+	--d(">no callback specified, deleting all contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "]")
 					registeredCallbacks = nil
 					toDeleteIndices[idx] = true
 				else
 					--Remove the callbacks of that uniqueAddonName entry
 					if registeredCallbacks[callbackName] ~= nil then
-	d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "][" .. tos(callbackName) .. "]")
+	--d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "][" .. tos(callbackName) .. "]")
 						registeredCallbacks[callbackName] = nil
 						--Check if any other callback is still registered there, else remove the total registered callbacks entry
 						if NonContiguousCount(registeredCallbacks) == 0 then
-	d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "]")
+	--d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."][" .. tos(loopedUniqueAddonName) .. "]")
 							registeredCallbacks = nil
 							toDeleteIndices[idx] = true
 						end
@@ -321,7 +333,7 @@ function contextMenuClass:UnregisterSpecialCallback(uniqueAddonName, callbackNam
 
 	if NonContiguousCount(toDeleteIndices) > 0 then
 		for idx, doDelete in pairs(toDeleteIndices) do
-d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."]")
+--d(">deleting contextMenuCallbacksRegistered[" .. tos(idx) .."]")
 			lib.contextMenuCallbacksRegistered[idx] = nil
 		end
 	end

--- a/LibScrollableMenu/classes/dropdown_class.lua
+++ b/LibScrollableMenu/classes/dropdown_class.lua
@@ -50,6 +50,7 @@ local zo_comboBoxDropdown_onMouseEnterEntry = ZO_ComboBoxDropdown_Keyboard.OnMou
 --LSM library locals
 --------------------------------------------------------------------
 local g_contextMenu
+local LSM_IsContextMenuCurrentlyShown
 
 local has_submenu = true
 local no_submenu = false
@@ -127,6 +128,24 @@ local filterFunc				--the filter function to use. Default is "defaultFilterFunc"
 local throttledCallDropdownClassSetFilterStringSuffix =  "_DropdownClass_SetFilterString"
 local throttledCallDropdownClassOnTextChangedStringSuffix =  "_DropdownClass_OnTextChanged"
 local throttledCallDropdownClassOnValueChangedStringSuffix =  "_DropdownClass_OnValueChanged"
+
+
+--ContextMenu
+local function checkIfContextMenuVisibleAndBringToTopAgain(dropdown, comboBox, delay) --#2026_13
+	--Check if contextMenu was shown/is open and bring it to the top again, after the refresh #2026_13
+	g_contextMenu = getContextMenuReference()
+	LSM_IsContextMenuCurrentlyShown = LSM_IsContextMenuCurrentlyShown or IsCustomScrollableContextMenuShown
+--d("[LSM]checkIfContextMenuVisibleAndBringToTopAgain - visible: " .. tos(LSM_IsContextMenuCurrentlyShown()))
+	if not LSM_IsContextMenuCurrentlyShown() then return end
+
+	delay = delay or 10
+
+	zo_callLater(function()
+--d(">Bringing LSM contextMenu to the top again (because of automatic menu/submenu resfresh")
+		g_contextMenu.m_dropdownObject.control:BringWindowToTop() --#2026_13
+	end, delay)
+end
+
 
 ------------------------------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------------------------------
@@ -208,7 +227,7 @@ end
 --#2025_44/2025_57 checkFunction to define we do not need an additional update of the current (sub)menu, as we are coming from the OnMouseUp runHandler and
 --dropdown:SubmenuOrCurrentListRefresh(control) is always called before! So we only need to update the parentMenu entries
 local function checkFuncOnMouseUpRunHandler_NoCurrentMenuUpdate(comboBox, control, data, isRecursiveCall, ...)
-d("[LSM]checkFuncOnMouseUpRundHandler_NoCurrentMenuUpdate - control: " .. getControlName(control) .. ", isRecursiveCall: " .. tos(isRecursiveCall))
+--d("[LSM]checkFuncOnMouseUpRundHandler_NoCurrentMenuUpdate - control: " .. getControlName(control) .. ", isRecursiveCall: " .. tos(isRecursiveCall))
 	--Always suppress the refresh try on either current entry's menu or submenu (depending on the return value of dropdown:SubmenuOrCurrentListRefresh(control) which was called at
 	--the runHandler["OnMouseUp"] already. But allow the following ones later (from the parentMenus, if available).
 	--Param isRecursiveCall == true will tell us that we are at the recursively parsed parentMenus
@@ -219,13 +238,13 @@ d("[LSM]checkFuncOnMouseUpRundHandler_NoCurrentMenuUpdate - control: " .. getCon
 	local LSM_menuRefreshVar = select(1, ...)
 	local entryControlUsedForOnMouseUpRunHandler = select(2, ...)
 	if not LSM_menuRefreshVar or entryControlUsedForOnMouseUpRunHandler == nil then
-		d("<1 fixed allowed")
+		--d("<1 fixed allowed")
 		--No menu update was done via runHandler["OnMouseUp"] , allow it now
 		return true
 	elseif LSM_menuRefreshVar ~= nil and entryControlUsedForOnMouseUpRunHandler ~= nil then
 		if LSM_menuRefreshVar == LSM_normalMenuRefreshDone then
 			--Menu update was done via runHandler["OnMouseUp"], only allow parentMenu update
-d("<2 isRecursiveCall: " ..tos(isRecursiveCall))
+--d("<2 isRecursiveCall: " ..tos(isRecursiveCall))
 			return isRecursiveCall
 		elseif LSM_menuRefreshVar == LSM_submenuRefreshDone then
 			local allowRefresh = false
@@ -240,13 +259,13 @@ d("<2 isRecursiveCall: " ..tos(isRecursiveCall))
 				if owner ~= nil and owner.openingControl ~= nil then
 					allowRefresh = owner.openingControl ~= control
 				end
-d(">entryControlUsedForOnMouseUpRunHandler: " .. tos(getControlName(entryControlUsedForOnMouseUpRunHandler)) .. ", owner: " .. tos(owner) .. ", openingControl: " .. tos(owner ~= nil and owner.openingControl or nil))
+--d(">entryControlUsedForOnMouseUpRunHandler: " .. tos(getControlName(entryControlUsedForOnMouseUpRunHandler)) .. ", owner: " .. tos(owner) .. ", openingControl: " .. tos(owner ~= nil and owner.openingControl or nil))
 			end
-d("<3 allowRefresh: " ..tos(allowRefresh))
+--d("<3 allowRefresh: " ..tos(allowRefresh))
 			return allowRefresh
 		end
 	end
-d("<4 fixed allowed")
+--d("<4 fixed allowed")
 	return true --allow the refresh in general (better twice than never)
 end
 
@@ -1827,6 +1846,7 @@ function dropdownClass:OnEntryMouseUp(control, button, upInside, ignoreHandler, 
 	--afterwards)
 	lib.preventerVars.suppressNextOnGlobalMouseUp = nil
 	lib.preventerVars.suppressNextOnEntryMouseUp = nil --#2025_13
+	lib.preventerVars.suppressNextHideContextMenuClearItems = nil --#2026_11
 
 	if upInside then
 		local data = getControlData(control)
@@ -2154,6 +2174,7 @@ function dropdownClass:IsAutomaticRefreshEnabled()
 	end
 end
 
+
 --#2025_42 Automatically update all entries (checkbox/radiobutton checked, and all entries enabled state) in a (sub)menu, if e.g. any other entry was clicked
 function dropdownClass:SubmenuOrCurrentListRefresh(control, override, refreshMainMenuOrSubmenu)
 	override = override or false
@@ -2174,6 +2195,7 @@ function dropdownClass:SubmenuOrCurrentListRefresh(control, override, refreshMai
 		zo_callLater(function() --delay the update of the entries a bit so all values have been updated properly before
 			comboBox:Show()
 		end, 15)
+		checkIfContextMenuVisibleAndBringToTopAgain(self, comboBox, 25) --#2026_13
 		return LSM_normalMenuRefreshDone --Normal menu refresh started
 	elseif automaticSubmenuRefresh == true and ( self.m_parentMenu ~= nil or (refreshMainMenuOrSubmenu ~= nil and refreshMainMenuOrSubmenu == false) ) then
 		--Submenu refresh
@@ -2185,6 +2207,7 @@ function dropdownClass:SubmenuOrCurrentListRefresh(control, override, refreshMai
 			-- Must clear now. Otherwise, moving onto a submenu will close it from exiting previous row.
 			clearTimeout()
 			self:ShowSubmenu(owner.openingControl)
+			checkIfContextMenuVisibleAndBringToTopAgain(self, comboBox, 10) --#2026_13
 			return LSM_submenuRefreshDone --Submenu refresh done
 		end
 	end

--- a/LibScrollableMenu/code/LSM_Util.lua
+++ b/LibScrollableMenu/code/LSM_Util.lua
@@ -97,6 +97,42 @@ function libUtil.checkIfValidTexturePath(texturePath) --#2025_63
 	return endsOnDDS
 end
 
+
+--------------------------------------------------------------------
+-- Preventer variable functions
+--------------------------------------------------------------------
+--If preventerVarName exists in lib.preventerVars then check if it is a boolean true and nil it again,
+--but if it's a number > 0 substract 1 until it get's 0, then nil it again
+function libUtil.checkAndUpdatePreventerVar(preventerVarName)
+	local preventerVar = lib.preventerVars[preventerVarName]
+	if preventerVar ~= nil then
+		if preventerVar == true then
+			lib.preventerVars[preventerVarName] = nil
+			return true
+		else
+			local fixPreventerVarNow = false
+			if type(preventerVar) == "number" then
+				if preventerVar > 0 then
+					local newPreventerVarNumber = preventerVar - 1
+					lib.preventerVars[preventerVarName] = (newPreventerVarNumber > 0 and newPreventerVarNumber) or nil
+					return true, newPreventerVarNumber
+				else
+					--Security fix to reset the variable if it was below or equal to 0
+					fixPreventerVarNow = true
+				end
+			else
+				--Security fix to reset the variable if it was no number or boolean
+				fixPreventerVarNow = true
+			end
+			if fixPreventerVarNow then
+				lib.preventerVars[preventerVarName] = nil
+			end
+		end
+	end
+end
+local libUtil_checkAndUpdatePreventerVar = libUtil.checkAndUpdatePreventerVar
+
+
 --------------------------------------------------------------------
 -- Controls
 --------------------------------------------------------------------
@@ -246,7 +282,7 @@ function libUtil.recursiveOverEntries(entry, comboBox, callback, ...)
 	]]
 
 	if endlessLoopPreventionCounter >= 5000 then
-d("["..MAJOR.."]recursiveOverEntries - EEEEEEEEEEEEEEE   --ABORT ENDLESS LOOP--   EEEEEEEEEEEEEE")
+d("["..MAJOR.."]ERROR recursiveOverEntries - EEEEEEEEEEEEEEE   --ABORT ENDLESS LOOP--   EEEEEEEEEEEEEE")
 		return
 	end
 
@@ -666,13 +702,18 @@ end
 local libUtil_BelongsToContextMenuCheck = libUtil.belongsToContextMenuCheck
 
 function libUtil.hideContextMenu()
-	--d(debugPrefix .. "hideContextMenu")
+--d("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	local suppressNextHideContextMenuClearItems = lib.preventerVars.suppressNextHideContextMenuClearItems
+--d(debugPrefix .. "hideContextMenu - suppressClearItems: " .. tos(suppressNextHideContextMenuClearItems))
+--d("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 	g_contextMenu = getContextMenuReference()
 	if g_contextMenu == nil then return end
 
 	if g_contextMenu:IsDropdownVisible() then
 		g_contextMenu:HideDropdown()
 	end
+
+	if libUtil_checkAndUpdatePreventerVar("suppressNextHideContextMenuClearItems") then return end
 	g_contextMenu:ClearItems()
 end
 local hideContextMenu = libUtil.hideContextMenu
@@ -695,7 +736,7 @@ end
 
 --Check if a context menu was shown and a control not belonging to that context menu was clicked
 --Returns boolean true if that was the case -> Prevent selection of entries or changes of radioButtons/checkboxes
---while a context menu was opened and one directly clicks on that other entry
+---while a context menu was opened and one directly clicks on that other entry
 function libUtil.checkIfContextMenuOpenedButOtherControlWasClicked(control, comboBox, buttonId)
 --d(debugPrefix .. "checkIfContextMenuOpenedButOtherControlWasClicked")
 	getContextMenuReference()
@@ -933,22 +974,18 @@ end
 
 --20250309 #2025_13 If the last comboBox_base:HiddenForReasons call closed an open contextMenu with multiSelect enabled, and we clicked on an LSM entry of another non-contextmenu
 --to close it, then just exit here and do not select the clicked entry
+--->Return true to skip next OnMouseUp, false to suppress the skip of next OnMouseUp
 function libUtil.checkNextOnEntryMouseUpShouldExecute()
---d(debugPrefix.."libUtil.checkNextOnEntryMouseUpShouldExecute - suppressNextOnEntryMouseUp:" ..tos(lib.preventerVars.suppressNextOnEntryMouseUp))
+--d(debugPrefix.."libUtil.checkNextOnEntryMouseUpShouldExecute - suppressNextOnEntryMouseUp:" ..tos(lib.preventerVars.suppressNextOnEntryMouseUp) .. ", suppressNextOnEntryMouseUpDisableCounter: " ..tos(lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter))
 	if lib.preventerVars.suppressNextOnEntryMouseUp == true then
 		--Was any special handling for the checkboxes/radiobuttons (clicked while an opened LSM contextMenu was on top of them) enabled. Disable the "skip" of next OnMouseUp so it not skipping it twice
-		if lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter ~= nil then
-			lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter = lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter - 1
-			if lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter <= 0 then
-				lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter = 0
-			end
-			if lib.preventerVars.suppressNextOnEntryMouseUpDisableCounter == 0 then
---d("<°°°suppressNextOnEntryMouseUpDisableCounter reached 0 -> Returning false -> Not skipping next OnMouseUp! °°°")
-				lib.preventerVars.suppressNextOnEntryMouseUp = nil
-				return false
-			end
+		local wasProcessed, newPreventerVarNumber = libUtil_checkAndUpdatePreventerVar("suppressNextOnEntryMouseUpDisableCounter")
+		if wasProcessed == true and newPreventerVarNumber ~= nil and newPreventerVarNumber == 0 then --#2026_14
+--d("<°°°suppressNextOnEntryMouseUpDisableCounter reached 0/nil -> Returning false -> Not skipping next OnMouseUp! °°°")
+			lib.preventerVars.suppressNextOnEntryMouseUp = nil
+			return false
 		end
---d("<!!! OnMosueup on LSM entry suppressed !!!")
+--d("<!!! OnMouseUp on LSM entry suppressed !!!")
 		lib.preventerVars.suppressNextOnEntryMouseUp = nil
 		return true
 	end
@@ -957,9 +994,12 @@ end
 
 function libUtil.isAnyLSMDropdownVisible(contextMenuToo)
 	if lib._objects == nil then return false end
+--d(debugPrefix .. "libUtil.isAnyLSMDropdownVisible-contextMenuToo: " ..tos(contextMenuToo))
+	getControlName = getControlName or libUtil.getControlName
 	for _, lsmRef in ipairs(lib._objects) do
 		if lsmRef ~= nil and lsmRef:IsDropdownVisible() then
 			if not contextMenuToo or (contextMenuToo and lsmRef.isContextMenu) then
+--d(">> YES: " ..tos(getControlName(lsmRef.m_container)))
 				return true
 			end
 		end

--- a/LibScrollableMenu/code/LibScrollableMenu.lua
+++ b/LibScrollableMenu/code/LibScrollableMenu.lua
@@ -19,7 +19,7 @@ local sfor = string.format
 local constants = lib.constants
 local entryTypeConstants = constants.entryTypes
 
-
+local libXML  = lib.XML
 local libUtil = lib.Util
 local getControlData = libUtil.getControlData
 local getValueOrCallback = libUtil.getValueOrCallback
@@ -119,8 +119,8 @@ libUtil.MapEntries = mapEntries
 --Called from XML at e.g. the collapsible header's editbox, and other controls
 --Used for event handlers like OnMouseUp, OnClicked and OnChanged etc.
 -->Calls the function owningWindowFunctionName inside the refVar, and passes in the parameters ...
-function lib.XML.OnXMLControlEventHandler(owningWindowFunctionName, refVar, ...)
-	--d(debugPrefix .. "lib.XML.OnXMLControlEventHandler - owningWindowFunctionName: " .. tos(owningWindowFunctionName))
+function libXML.OnXMLControlEventHandler(owningWindowFunctionName, refVar, ...)
+--d(debugPrefix .. "lib.XML.OnXMLControlEventHandler - owningWindowFunctionName: " .. tos(owningWindowFunctionName))
 	if refVar == nil or owningWindowFunctionName == nil then return end
 
 	local owningWindow = refVar:GetOwningWindow()
@@ -137,7 +137,7 @@ end
 
 
 --XML OnClick handler for checkbox and radiobuttons
-function lib.XML.XMLButtonOnInitialize(control, entryType)
+function libXML.XMLButtonOnInitialize(control, entryType)
 	--Which XML button control's handler was used, checkbox or radiobutton?
 	local isCheckbox = entryType == entryTypeConstants.LSM_ENTRY_TYPE_CHECKBOX
 	local isRadioButton = not isCheckbox and entryType == entryTypeConstants.LSM_ENTRY_TYPE_RADIOBUTTON
@@ -145,9 +145,19 @@ function lib.XML.XMLButtonOnInitialize(control, entryType)
 	control:GetParent():SetHandler('OnMouseUp', function(parent, buttonId, upInside, ...)
 --d(debugPrefix .. "XML-OnMouseUp of parent-upInside: " ..tos(upInside) .. ", buttonId: " .. tos(buttonId))
 		if upInside then
-			if checkIfContextMenuOpenedButOtherControlWasClicked(control, parent.m_owner, buttonId) == true then return end
+			if checkIfContextMenuOpenedButOtherControlWasClicked(control, parent.m_owner, buttonId) == true then
+--d("<aborting due to checkIfContextMenuOpenedButOtherControlWasClicked, skipNextOnMouseUp: " .. tos(lib.preventerVars.suppressNextOnEntryMouseUp))
+				return
+			end
 			if buttonId == MOUSE_BUTTON_INDEX_LEFT then
-				if checkNextOnEntryMouseUpShouldExecute() then return end
+				--#2026-01 Here lib.preventerVars.suppressNextOnEntryMouseUp is already true and that way the first click on a checkbox or radio button,
+				--after clicked on another checkbox before and then clossing and reopening the menu, is suppressed
+				--20260606 Maybe the variable lib.preventerVars.suppressNextOnEntryMouseUp needs to be reset on each comboBox's ShowMenu calls?
+
+				if checkNextOnEntryMouseUpShouldExecute() then
+--d("<aborting due to checkNextOnEntryMouseUpShouldExecute, skipNextOnMouseUp: " .. tos(lib.preventerVars.suppressNextOnEntryMouseUp)) --#2026_01
+					return
+				end
 
 				local data = getControlData(parent)
 				local dropdown = parent.m_dropdownObject
@@ -155,9 +165,9 @@ function lib.XML.XMLButtonOnInitialize(control, entryType)
 
 				local onClickedHandler = control:GetHandler('OnClicked')
 				if onClickedHandler then
-					onClickedHandler(control, buttonId)
+					onClickedHandler(control, buttonId) --Calls the OnClicked function below (for checkboxes only, radiobuttons use their default OnClicked handler) now
 
-					dropdown:SubmenuOrCurrentListRefresh(control) --#2025_42
+					dropdown:SubmenuOrCurrentListRefresh(control) --#2025_42 #2026_14 disable
 				end
 
 			elseif buttonId == MOUSE_BUTTON_INDEX_RIGHT then
@@ -174,19 +184,30 @@ function lib.XML.XMLButtonOnInitialize(control, entryType)
 		end
 	end)
 
+	--Checkboxes only!
 	if not isRadioButton then
 		local originalClicked = control:GetHandler('OnClicked')
 		control:SetHandler('OnClicked', function(p_control, buttonId, ignoreCallback, skipHiddenForReasonsCheck, ...)
+--d(debugPrefix .. "XML-OnClicked - buttonId: " .. tos(buttonId) .. ", skipHiddenForReasonsCheck: " ..tos(skipHiddenForReasonsCheck))
 			skipHiddenForReasonsCheck = skipHiddenForReasonsCheck or false
-			if not skipHiddenForReasonsCheck then
-				local parent = p_control:GetParent()
-				local comboBox = parent.m_owner
-				if checkIfContextMenuOpenedButOtherControlWasClicked(p_control, comboBox, buttonId) == true then return end
-			end
-			if checkNextOnEntryMouseUpShouldExecute() then return end
+local prevVars = lib.preventerVars --#2026_01
+--d("PreventerVars-skipNextOnMouseUp: " .. tos(prevVars.suppressNextOnEntryMouseUp) .. ", skipNextGlobalMouseUp: " ..tos(prevVars.suppressNextOnGlobalMouseUp) .. ", skipNextGlobalMouseUp: " ..tos(prevVars.suppressNextOnEntryMouseUpDisableCounter))
 
+			if not skipHiddenForReasonsCheck then
+				local comboBox = (p_control.toggleFunction ~= nil and p_control:GetParent().m_owner) or p_control.m_owner --#2026_14
+				--Check if we clicked the row or the actual checkbox/radiobutton icon in the row -> in that case get the parentControl (the row)
+				if checkIfContextMenuOpenedButOtherControlWasClicked(p_control, comboBox, buttonId) == true then
+--d("<aborting due to checkIfContextMenuOpenedButOtherControlWasClicked, skipNextOnMouseUp: " .. tos(lib.preventerVars.suppressNextOnEntryMouseUp))
+					return
+				end
+			end
+			if checkNextOnEntryMouseUpShouldExecute() then
+				return
+--d("<<aborting due to checkNextOnEntryMouseUpShouldExecute, skipNextOnMouseUp: " .. tos(lib.preventerVars.suppressNextOnEntryMouseUp))
+			end
 			if originalClicked then
-				originalClicked(p_control, buttonId, ignoreCallback, ...)
+--d(">originalClicked called!")
+				originalClicked(p_control, buttonId, ignoreCallback, ...) -- Calls ZO_CheckButton_OnClicked: OnClicked function was set at comboBox_base:SetupEntryCheckbox -> local addCheckButton -> ZO_CheckButton_SetToggleFunction -> local toggleFunction (in comboBox_base:SetupEntryCheckbox)
 			end
 			p_control.checked = nil
 		end)
@@ -198,7 +219,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 
 --Load of the addon/library starts
-local function onAddonLoaded(event, name)
+local function onAddonLoaded(eventId, name)
 	if name:find("^ZO_") then return end
 	EM:UnregisterForEvent(MAJOR, EVENT_ADD_ON_LOADED)
 
@@ -281,9 +302,10 @@ EM:RegisterForEvent(MAJOR, EVENT_ADD_ON_LOADED, onAddonLoaded)
 
 
 ---------------------------------------------------------------
-	CHANGELOG Current version: 2.43 - Updated 2026-05-26
+	CHANGELOG Current version: 2.44 - Updated 2026-06-06
 ---------------------------------------------------------------
-Max error #: 2026_12
+Max error #: 2026_14
+
 
 [WORKING ON]
 
@@ -293,19 +315,20 @@ Max error #: 2026_12
 --======================================================================================================================
 [KNOWN PROBLEMS]
 --======================================================================================================================
---#2026_01 After a LSM contextMenu was shown and a checkbox was clicked (on the checkbox's label!), the next opened contextMenu's checkbox label
+--#2026_01 After a LSM contextMenu was shown and a checkbox was clicked (on the checkbox's label, not the icon!), the next opened contextMenu's checkbox label
   is not changing the checkbox state (as if the first click is not accepted?), only the 2nd click does. (noticed during BMU LCM -> LSM changes at 2026-01-25)
 --#2026_03 Search header contextMenu for last searched does not work on BeamMeUp item filter header?
---#2026_11 Opening a LibSets search UI dropdown e.g. at the DLCIDs and while having it opened left click the gear settings icon at the top tight setSearchUI just shows an empty settings contextMenu (as if ClearCustomScrollableMenu was called?)
+
 --======================================================================================================================
 
 
 [Fixed]
+--#2026_01 1st click on a checkbox/radio button in a new opened contextMenu, after another contextMenu was opened before and a checkbox/radiobutton was clicked inside, did not work
+--#2026_11 Opening a contextMenu from a non LSM control (e.g. custom button to show the contextMenu on) showed the contextMenu empty, if another LSM non-contextMenu dropdown was opened at that time)
+--#2026_13 Opening a contextmenu sometimes made it vanish behind the openingControl, due to the automatic (sub)menuRefreshs (if enabled)
+--#2026_14 Checkboxes/Radiobuttons clicked in opened submenus closed the submenus sometimes
 
 [Added]
---#2026_09 Custom sorting default values (customSortKey: applied once as the LSM is initialized), and a custom sort function customSortFunc, signature function(table entry1, table entry2, table:nilable comboboxObject): return boolean
---#2026_10 options.enableSort Show ^v sort header icons at the dropdown (collapsible) header -> Only if enableFilter == true, and not working at contextMenus or submenus
---#2026_12 Adding nilable:table options.customSortDownButton = { nilable:table dimensions = { number x = 18, number y = 18 }, nilable:table texture = { up = "", normal = "", pressed = "", disabled = "" }, nilable:table anchor = { number:pointOnMe = LEFT, target = userdata:control, number:pointOnTarget = LEFT, nilable:number offsetX = 0, nilable:number offsetY = 0 }, and options.customSortUpButton
 
 [Changed]
 
@@ -320,6 +343,5 @@ TODO - To check (future versions)
 ---------------------------------------------------------------
 UPCOMING FEATURES  - What could be added in the future?
 ---------------------------------------------------------------
-	1. Sort headers for the dropdown (ascending/descending) (maybe: allowing custom sort functions too)
-	2. LibCustomMenu and ZO_Menu replacement (currently postponed, see code at branch LSM v2.4) due to several problems with ZO_Menu (e.g. zo_callLater used by addons during context menu addition) and chat, and other problems
+	1. LibCustomMenu and ZO_Menu replacement (currently postponed, see code at branch LSM v2.4) due to several problems with ZO_Menu (e.g. zo_callLater used by addons during context menu addition) and chat, and other problems
 ]]

--- a/LibScrollableMenu/constants.lua
+++ b/LibScrollableMenu/constants.lua
@@ -6,7 +6,7 @@ if LibScrollableMenu ~= nil then return end -- the same or newer version of this
 local lib = ZO_CallbackObject:New()
 lib.name = "LibScrollableMenu"
 lib.author = "Baertram, IsJustaGhost, tomstock, Kyoma"
-lib.version = "2.43"
+lib.version = "2.44"
 if not lib then return end
 --------------------------------------------------------------------
 
@@ -29,10 +29,11 @@ lib._objects = {}
 
 --PreventerVariables
 lib.preventerVars = {
-	--suppressNextOnGlobalMouseUp = nil, --used in comboBox_base:OnGlobalMouseUp and comboBox_base:HiddenForReasons; if this is true the next globalOnMouseUp event on any control is skipped (e.g. to suppress the LSM menus closing by clicking somewhere on GuiRoot as a LSM contextMenu was opened)
+	--suppressNextOnGlobalMouseUp = nil, --used in comboBox_base:OnGlobalMouseUp and comboBox_base:HiddenForReasons; if this is true the next globalOnMouseUp event on any control is skipped (e.g. to suppress the LSM menus closing by clicking somewhere on GuiRoot as a LSM contextMenu was opened). If this is a number it is the mouseButton to check against for the global mouse up event!
 	--suppressNextOnEntryMouseUp = nil,  --used in comboBox_base:HiddenForReasons and dropdownClass:OnEntryMouseUp; if this is true the next OnMouseUp event on any LSM control is skipped (e.g. to suppress the LSM entries to be selected by clicking on a LSM entry beklow an opened LSM contextmenu)
 	--suppressNextOnEntryMouseUpDisableCounter = 0 --used in comboBox_base:HiddenForReasons and dropdownClass:OnEntryMouseUp; if this counter is ~= nil and > 0, it will count the suppressNextOnEntryMouseUp down by 1 each and if it reaches 0 it will reset suppressNextOnEntryMouseUp to nil (e.g. by clicking on a checkbox/radiobutton below an opened LSM contextMenu, the suppressNextOnEntryMouseUp might get set true twice. So we need to skip the 2nd one then)
 	--wasContextMenuOpenedAsOnMouseUpWasSuppressed = nil, --used in comboBox_base closeContextMenuAndSuppressClickCheck, and dropdownClass:OnEntryMouseUp
+	--suppressNextHideContextMenuClearItems = nil, --#2026_11 number - suppress the next n contextMenu's ClearItems() call, via lib.util.hideContextMenu() function. e.g. if contextMenuClass:ShowContextMenu() is detecting that an already opened dropdown of a non-contextMenu should be closed after we directly clicked (having that other LSM's dropdown still opened) on another custom control (eg. a button) to open the contextmenu now -> The contextMenu items would be empty then
 }
 
 --Library's XML functions and code

--- a/LibScrollableMenu/test/LSM_test.lua
+++ b/LibScrollableMenu/test/LSM_test.lua
@@ -143,7 +143,6 @@ local function test()
 			enableSort = function() return true end, --#2026_10
 			sortOrder = ZO_SORT_ORDER_DOWN,
 			sortType = ZO_SORT_BY_NAME,
-			sortEntries = true,
 			customSortUpButton = { 					   --#2026_12
 				dimensions = { x = 16, y = 16 },
 			    texture = {


### PR DESCRIPTION
LSM v2.43 - 2026-06-06
[FIXED]
-#2026_01 1st click on a checkbox/radio button in a new opened contextMenu, after another contextMenu was opened before and a checkbox/radiobutton was clicked inside, did not work
-#2026_11 Opening a contextMenu from a non LSM control (e.g. custom button to show the contextMenu on) showed the contextMenu empty, if another LSM non-contextMenu dropdown was opened at that time)
-#2026_13 Opening a contextmenu sometimes made it vanish behind the openingControl, due to the automatic (sub)menuRefreshs (if enabled)
-#2026_14 Checkboxes/Radiobuttons clicked in opened submenus closed the submenus sometimes